### PR TITLE
Remove dependency to UnsafeHelper

### DIFF
--- a/hazelcast-hibernate5/pom.xml
+++ b/hazelcast-hibernate5/pom.xml
@@ -42,9 +42,6 @@
                         <artifactId>java16</artifactId>
                         <version>1.0</version>
                     </signature>
-                    <ignores>
-                        <ignore>sun.misc.Unsafe</ignore>
-                    </ignores>
                 </configuration>
                 <executions>
                     <execution>

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
@@ -17,7 +17,6 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.logging.Logger;
-import com.hazelcast.nio.UnsafeHelper;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.SerializerHook;
 
@@ -34,12 +33,10 @@ public class Hibernate5CacheEntrySerializerHook
 
     public Hibernate5CacheEntrySerializerHook() {
         Class<?> cacheEntryClass = null;
-        if (UnsafeHelper.UNSAFE_AVAILABLE) {
-            try {
-                cacheEntryClass = Class.forName("org.hibernate.cache.spi.entry.StandardCacheEntryImpl");
-            } catch (Exception e) {
-                Logger.getLogger(Hibernate5CacheEntrySerializerHook.class).finest(SKIP_INIT_MSG);
-            }
+        try {
+            cacheEntryClass = Class.forName("org.hibernate.cache.spi.entry.StandardCacheEntryImpl");
+        } catch (Exception e) {
+            Logger.getLogger(Hibernate5CacheEntrySerializerHook.class).finest(SKIP_INIT_MSG);
         }
         this.cacheEntryClass = cacheEntryClass;
     }

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/serialization/Hibernate5CacheEntrySerializerHook.java
@@ -17,7 +17,6 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.logging.Logger;
-import com.hazelcast.nio.UnsafeHelper;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.SerializerHook;
 
@@ -33,14 +32,12 @@ public class Hibernate5CacheEntrySerializerHook implements SerializerHook {
 
     public Hibernate5CacheEntrySerializerHook() {
         Class<?> cacheEntryClass = null;
-        if (UnsafeHelper.UNSAFE_AVAILABLE) {
-            try {
-                // check if Hibernate is available
-                Class.forName("org.hibernate.cache.spi.entry.CacheEntry");
-                cacheEntryClass = CacheEntryImpl.class;
-            } catch (Exception e) {
-                Logger.getLogger(Hibernate5CacheEntrySerializerHook.class).finest(SKIP_INIT_MSG);
-            }
+        try {
+            // check if Hibernate is available
+            Class.forName("org.hibernate.cache.spi.entry.CacheEntry");
+            cacheEntryClass = CacheEntryImpl.class;
+        } catch (Exception e) {
+            Logger.getLogger(Hibernate5CacheEntrySerializerHook.class).finest(SKIP_INIT_MSG);
         }
         this.cacheEntryClass = cacheEntryClass;
     }


### PR DESCRIPTION
As it turned out, unsafe functionality is not needed at all since there
are no classes doing actual usage of unsafe features.

IMDG counterpart: https://github.com/hazelcast/hazelcast/pull/15330