### PR TITLE
Make testQueryCacheCleanup() deterministic

### DIFF
--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -48,13 +48,10 @@ public class RegionFactoryDefaultSlowTest
 
     @Test
     public void testQueryCacheCleanup() {
-
         MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
-        final float baseEvictionRate = 0.2f;
-        final int numberOfEntities = 100;
-        final int defaultCleanupPeriod = 60;
         final int maxSize = mapConfig.getEvictionConfig().getSize();
-        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+
+        final int numberOfEntities = 100;
         insertDummyEntities(numberOfEntities);
         for (int i = 0; i < numberOfEntities; i++) {
             executeQuery(sf, i);
@@ -64,8 +61,8 @@ public class RegionFactoryDefaultSlowTest
         assertEquals(numberOfEntities, queryRegion.getCache().size());
 
         await()
-          .atMost(defaultCleanupPeriod + 1, TimeUnit.SECONDS)
-          .until(() -> (numberOfEntities - evictedItemCount) == queryRegion.getCache().size());
+          .atMost(61, TimeUnit.SECONDS)
+          .until(() -> (queryRegion.getCache().size() < maxSize));
     }
 
     @Test

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -49,9 +49,9 @@ public class RegionFactoryDefaultSlowTest
     @Test
     public void testQueryCacheCleanup() {
         MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
-        final int maxSize = mapConfig.getEvictionConfig().getSize();
-
         final int numberOfEntities = 100;
+        final int maxSize = Math.min(mapConfig.getEvictionConfig().getSize(), numberOfEntities);
+
         insertDummyEntities(numberOfEntities);
         for (int i = 0; i < numberOfEntities; i++) {
             executeQuery(sf, i);

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -47,13 +47,10 @@ public class RegionFactoryDefaultSlowTest
 
     @Test
     public void testQueryCacheCleanup() {
-
         MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
-        final float baseEvictionRate = 0.2f;
-        final int numberOfEntities = 100;
-        final int defaultCleanupPeriod = 60;
         final int maxSize = mapConfig.getEvictionConfig().getSize();
-        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+
+        final int numberOfEntities = 100;
         insertDummyEntities(numberOfEntities);
         for (int i = 0; i < numberOfEntities; i++) {
             executeQuery(sf, i);
@@ -63,8 +60,8 @@ public class RegionFactoryDefaultSlowTest
         assertEquals(numberOfEntities, queryRegion.getCache().size());
 
         await()
-          .atMost(defaultCleanupPeriod + 1, TimeUnit.SECONDS)
-          .until(() -> (numberOfEntities - evictedItemCount) == queryRegion.getCache().size());
+          .atMost(61, TimeUnit.SECONDS)
+          .until(() -> (queryRegion.getCache().size() < maxSize));
     }
 
     @Test

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -48,9 +48,10 @@ public class RegionFactoryDefaultSlowTest
     @Test
     public void testQueryCacheCleanup() {
         MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
-        final int maxSize = mapConfig.getEvictionConfig().getSize();
 
         final int numberOfEntities = 100;
+        final int maxSize = Math.min(mapConfig.getEvictionConfig().getSize(), numberOfEntities);
+
         insertDummyEntities(numberOfEntities);
         for (int i = 0; i < numberOfEntities; i++) {
             executeQuery(sf, i);


### PR DESCRIPTION
The integration test should merely verify if the cleanup is triggered and the functionality of `CleanupService` should be tested in separation.
