### PR TITLE
Introduce EvictionConfig interface to decouple cache eviction from MapConfig

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -31,6 +31,7 @@ import com.hazelcast.topic.MessageListener;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.access.SoftLock;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -60,6 +61,7 @@ public class LocalRegionCache implements RegionCache {
     protected final Comparator versionComparator;
     protected final AtomicLong markerIdCounter;
     protected MapConfig config;
+    private final EvictionConfig evictionConfig;
 
     /**
      * @param name              the name for this region cache, which is also used to retrieve configuration/topic
@@ -86,6 +88,26 @@ public class LocalRegionCache implements RegionCache {
      */
     public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
                             final CacheDataDescription metadata, final boolean withTopic) {
+        this(name, hazelcastInstance, metadata, withTopic, null);
+    }
+
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with if {@code withTopic} is {@code true} (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     * @param withTopic         {@code true} to register a {@link MessageListener} with the {@link ITopic} whose name
+     *                          matches this region cache <i>if</i> a {@code HazelcastInstance} was provided to look
+     *                          up the topic; otherwise, {@code false} not to register a listener even if an instance
+     *                          was provided
+     * @param evictionConfig    provides the parameters which should be used when evicting entries from the cache;
+     *                          if null, this will be derived from the Hazelcast {@link MapConfig}; if the MapConfig
+     *                          cannot be resolved, this will use defaults.
+     */
+    public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                            final CacheDataDescription metadata, final boolean withTopic,
+                            final EvictionConfig evictionConfig) {
         this.hazelcastInstance = hazelcastInstance;
         try {
             config = hazelcastInstance != null ? hazelcastInstance.getConfig().findMapConfig(name) : null;
@@ -103,6 +125,7 @@ public class LocalRegionCache implements RegionCache {
         } else {
             topic = null;
         }
+        this.evictionConfig = evictionConfig == null ? EvictionConfig.create(config) : evictionConfig;
     }
 
     @Override
@@ -287,15 +310,8 @@ public class LocalRegionCache implements RegionCache {
     }
 
     void cleanup() {
-        final int maxSize;
-        final long timeToLive;
-        if (config != null) {
-            maxSize = config.getEvictionConfig().getSize();
-            timeToLive = config.getTimeToLiveSeconds() * SEC_TO_MS;
-        } else {
-            maxSize = MAX_SIZE;
-            timeToLive = CacheEnvironment.getDefaultCacheTimeoutInMillis();
-        }
+        final int maxSize = evictionConfig.getMaxSize();
+        final long timeToLive = evictionConfig.getTimeToLive().toMillis();
 
         boolean limitSize = maxSize > 0 && maxSize != Integer.MAX_VALUE;
         if (limitSize || timeToLive > 0) {
@@ -432,6 +448,44 @@ public class LocalRegionCache implements RegionCache {
         @Override
         public int hashCode() {
             return key == null ? 0 : key.hashCode();
+        }
+    }
+
+    /**
+     * Defines the parameters used when evicting entries from the cache.
+     */
+    public interface EvictionConfig {
+        /**
+         * @return the duration for which an item should live in the cache
+         */
+        Duration getTimeToLive();
+
+        /**
+         * @return the maximum number of entries that should live in the cache
+         */
+        int getMaxSize();
+
+        /**
+         * Creates an {@link EvictionConfig} for a given Hazelcast {@link MapConfig}.
+         *
+         * @param mapConfig the MapConfig to use. If null, defaults will be used.
+         */
+        static EvictionConfig create(final MapConfig mapConfig) {
+            return new EvictionConfig() {
+                @Override
+                public Duration getTimeToLive() {
+                    return mapConfig == null
+                      ? Duration.ofMillis(CacheEnvironment.getDefaultCacheTimeoutInMillis())
+                      : Duration.ofSeconds(mapConfig.getTimeToLiveSeconds());
+                }
+
+                @Override
+                public int getMaxSize() {
+                    return mapConfig == null
+                      ? MAX_SIZE
+                      : mapConfig.getEvictionConfig().getSize();
+                }
+            };
         }
     }
 }

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.hibernate.local;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
@@ -12,6 +13,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.UUID;
 
@@ -69,6 +71,44 @@ public class LocalRegionCacheTest {
         verify(config).findMapConfig(eq(CACHE_NAME));
         verify(instance).getConfig();
         verify(instance, never()).getTopic(anyString());
+    }
+
+    @Test
+    public void testEvictionConfigIsDerivedFromMapConfig() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        EvictionConfig maxSizeConfig = mock(EvictionConfig.class);
+        when(mapConfig.getEvictionConfig()).thenReturn(maxSizeConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false)
+          .cleanup();
+
+        verify(maxSizeConfig).getSize();
+        verify(mapConfig).getTimeToLiveSeconds();
+    }
+
+    @Test
+    public void testEvictionConfigIsNotDerivedFromMapConfig() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        LocalRegionCache.EvictionConfig evictionConfig = mock(LocalRegionCache.EvictionConfig.class);
+        when(evictionConfig.getTimeToLive()).thenReturn(Duration.ofSeconds(1));
+
+        new LocalRegionCache(CACHE_NAME, null, null, false, evictionConfig)
+          .cleanup();
+
+        verify(evictionConfig).getMaxSize();
+        verify(evictionConfig).getTimeToLive();
+        verifyZeroInteractions(mapConfig);
     }
 
     // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -36,6 +36,7 @@ import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.cache.spi.support.AbstractReadWriteAccess;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -62,6 +63,7 @@ public class LocalRegionCache implements RegionCache {
     private final RegionFactory regionFactory;
     private final ITopic<Object> topic;
     private final Comparator versionComparator;
+    private final EvictionConfig evictionConfig;
 
     private MapConfig config;
 
@@ -93,6 +95,27 @@ public class LocalRegionCache implements RegionCache {
     public LocalRegionCache(final RegionFactory regionFactory, final String name,
                             final HazelcastInstance hazelcastInstance, final DomainDataRegionConfig regionConfig,
                             final boolean withTopic) {
+        this(regionFactory, name, hazelcastInstance, regionConfig, withTopic, null);
+    }
+
+    /**
+     * @param regionFactory     the region factory
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with if {@code withTopic} is {@code true} (optional)
+     * @param regionConfig      the region configuration
+     * @param withTopic         {@code true} to register a {@link MessageListener} with the {@link ITopic} whose name
+     *                          matches this region cache <i>if</i> a {@code HazelcastInstance} was provided to look
+     *                          up the topic; otherwise, {@code false} not to register a listener even if an instance
+     *                          was provided
+     * @param evictionConfig    provides the parameters which should be used when evicting entries from the cache;
+     *                          if null, this will be derived from the Hazelcast {@link MapConfig}; if the MapConfig
+     *                          cannot be resolved, this will use defaults.
+     */
+    public LocalRegionCache(final RegionFactory regionFactory, final String name,
+                            final HazelcastInstance hazelcastInstance, final DomainDataRegionConfig regionConfig,
+                            final boolean withTopic, final EvictionConfig evictionConfig) {
         this.hazelcastInstance = hazelcastInstance;
         this.name = name;
         this.regionFactory = regionFactory;
@@ -112,6 +135,7 @@ public class LocalRegionCache implements RegionCache {
         }
 
         versionComparator = findVersionComparator(regionConfig);
+        this.evictionConfig = evictionConfig == null ? EvictionConfig.create(config) : evictionConfig;
     }
 
     @Override
@@ -206,15 +230,8 @@ public class LocalRegionCache implements RegionCache {
 
     @SuppressWarnings("Duplicates")
     void cleanup() {
-        final int maxSize;
-        final long timeToLive;
-        if (config != null) {
-            maxSize = config.getEvictionConfig().getSize();
-            timeToLive = config.getTimeToLiveSeconds() * SEC_TO_MS;
-        } else {
-            maxSize = MAX_SIZE;
-            timeToLive = CacheEnvironment.getDefaultCacheTimeoutInMillis();
-        }
+        final int maxSize = evictionConfig.getMaxSize();
+        final long timeToLive = evictionConfig.getTimeToLive().toMillis();
 
         final boolean limitSize = maxSize > 0 && maxSize != Integer.MAX_VALUE;
         if (limitSize || timeToLive > 0) {
@@ -358,6 +375,44 @@ public class LocalRegionCache implements RegionCache {
         @Override
         public int hashCode() {
             return key == null ? 0 : key.hashCode();
+        }
+    }
+
+    /**
+     * Defines the parameters used when evicting entries from the cache.
+     */
+    public interface EvictionConfig {
+        /**
+         * @return the duration for which an item should live in the cache
+         */
+        Duration getTimeToLive();
+
+        /**
+         * @return the maximum number of entries that should live in the cache
+         */
+        int getMaxSize();
+
+        /**
+         * Creates an {@link EvictionConfig} for a given Hazelcast {@link MapConfig}.
+         *
+         * @param mapConfig the MapConfig to use. If null, defaults will be used.
+         */
+        static EvictionConfig create(final MapConfig mapConfig) {
+            return new EvictionConfig() {
+                @Override
+                public Duration getTimeToLive() {
+                    return mapConfig == null
+                      ? Duration.ofMillis(CacheEnvironment.getDefaultCacheTimeoutInMillis())
+                      : Duration.ofSeconds(mapConfig.getTimeToLiveSeconds());
+                }
+
+                @Override
+                public int getMaxSize() {
+                    return mapConfig == null
+                      ? MAX_SIZE
+                      : mapConfig.getEvictionConfig().getSize();
+                }
+            };
         }
     }
 }

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.hibernate.local;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
@@ -16,6 +17,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.UUID;
@@ -110,6 +112,44 @@ public class LocalRegionCacheTest {
         verify(config).findMapConfig(eq(CACHE_NAME));
         verify(instance).getConfig();
         verify(instance, never()).getTopic(anyString());
+    }
+
+    @Test
+    public void testEvictionConfigIsDerivedFromMapConfig() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        EvictionConfig maxSizeConfig = mock(EvictionConfig.class);
+        when(mapConfig.getEvictionConfig()).thenReturn(maxSizeConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, instance, null, false)
+          .cleanup();
+
+        verify(maxSizeConfig).getSize();
+        verify(mapConfig).getTimeToLiveSeconds();
+    }
+
+    @Test
+    public void testEvictionConfigIsNotDerivedFromMapConfig() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        LocalRegionCache.EvictionConfig evictionConfig = mock(LocalRegionCache.EvictionConfig.class);
+        when(evictionConfig.getTimeToLive()).thenReturn(Duration.ofSeconds(1));
+
+        new LocalRegionCache(regionFactory, CACHE_NAME, null, null, false, evictionConfig)
+          .cleanup();
+
+        verify(evictionConfig).getMaxSize();
+        verify(evictionConfig).getTimeToLive();
+        verifyZeroInteractions(mapConfig);
     }
 
     // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance


### PR DESCRIPTION
Port of: https://github.com/hazelcast/hazelcast-hibernate5/pull/82

----

closes https://github.com/hazelcast/hazelcast-hibernate5/issues/80
