### PR TITLE
[PoC] Datasource failover (approach 1)

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -16,6 +16,7 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.hibernate.instance.DefaultHazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -16,7 +16,6 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.hibernate.instance.DefaultHazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceFactory;
 import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -35,14 +35,14 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
     private static final int INITIAL_BACKOFF_MS = 2000;
     private static final int MAX_BACKOFF_MS = 35000;
-    private static final double BACKOFF_MULTIPLIER = 1.5D;
+    private static final double BACKOFF_MULTIPLIER = 1D;
 
     private HazelcastInstance client;
     private ClientConfig clientConfig;
     private String instanceName;
 
     @Override
-    public void configure(final Properties props) {
+    public void     configure(final Properties props) {
         instanceName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_INSTANCE_NAME, props, null);
         if (instanceName != null) {
             return;
@@ -77,6 +77,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(Long.MAX_VALUE);
     }
 
     @Override

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -85,9 +85,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     @Override
     protected DomainDataStorageAccess createDomainDataStorageAccess(final DomainDataRegionConfig regionConfig,
                                                                     final DomainDataRegionBuildingContext buildingContext) {
-        return new HazelcastStorageAccessImpl(
-                createRegionCache(regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig)
-        );
+        return new HazelcastStorageAccessImpl(createRegionCache(regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig), buildingContext.getSessionFactory().getProperties());
     }
 
     @Override
@@ -97,7 +95,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         // queries
         final LocalRegionCache regionCache = new LocalRegionCache(this, regionName, instance, null, false);
         cleanupService.registerCache(regionCache);
-        return new HazelcastStorageAccessImpl(regionCache);
+        return new HazelcastStorageAccessImpl(regionCache, sessionFactory.getProperties());
     }
 
     protected abstract RegionCache createRegionCache(final String unqualifiedRegionName,
@@ -107,9 +105,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     @Override
     protected StorageAccess createTimestampsRegionStorageAccess(final String regionName,
                                                                 final SessionFactoryImplementor sessionFactory) {
-        return new HazelcastStorageAccessImpl(
-                createTimestampsRegionCache(regionName, sessionFactory)
-        );
+        return new HazelcastStorageAccessImpl(createTimestampsRegionCache(regionName, sessionFactory), sessionFactory.getProperties());
     }
 
     protected abstract RegionCache createTimestampsRegionCache(final String regionName,

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -85,7 +85,9 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     @Override
     protected DomainDataStorageAccess createDomainDataStorageAccess(final DomainDataRegionConfig regionConfig,
                                                                     final DomainDataRegionBuildingContext buildingContext) {
-        return new HazelcastStorageAccessImpl(createRegionCache(regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig), buildingContext.getSessionFactory().getProperties());
+        return new HazelcastStorageAccessImpl(createRegionCache(
+          regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig),
+          buildingContext.getSessionFactory().getProperties());
     }
 
     @Override
@@ -105,7 +107,9 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     @Override
     protected StorageAccess createTimestampsRegionStorageAccess(final String regionName,
                                                                 final SessionFactoryImplementor sessionFactory) {
-        return new HazelcastStorageAccessImpl(createTimestampsRegionCache(regionName, sessionFactory), sessionFactory.getProperties());
+        return new HazelcastStorageAccessImpl(
+          createTimestampsRegionCache(regionName, sessionFactory),
+          sessionFactory.getProperties());
     }
 
     protected abstract RegionCache createTimestampsRegionCache(final String regionName,

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -32,6 +32,7 @@ import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.DomainDataRegion;
 import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.cache.spi.support.RegionFactoryTemplate;
+import org.hibernate.cache.spi.support.SimpleTimestamper;
 import org.hibernate.cache.spi.support.StorageAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 
@@ -69,6 +70,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     @Override
     public DomainDataRegion buildDomainDataRegion(final DomainDataRegionConfig regionConfig,
                                                   final DomainDataRegionBuildingContext buildingContext) {
+
         return new HazelcastDomainDataRegionImpl(
                 regionConfig,
                 this,
@@ -80,6 +82,16 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
 
     public HazelcastInstance getHazelcastInstance() {
         return instance;
+    }
+
+    @Override
+    public long nextTimestamp() {
+        try {
+            return HazelcastTimestamper.nextTimestamp(instance);
+        } catch (Exception e) {
+            log.finest(e.getMessage(), e);
+            return SimpleTimestamper.next();
+        }
     }
 
     @Override

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -75,6 +76,11 @@ public final class CacheEnvironment {
     public static final String HAZELCAST_INSTANCE_NAME = "hibernate.cache.hazelcast.instance_name";
 
     /**
+     * Property to enable fallback on datasource if Hazelcast cluster is not available
+     */
+    public static final String FALLBACK = "hibernate.cache.hazelcast.fallback";
+
+    /**
      * Property to configure explicitly checks the CacheEntry's version while updating RegionCache.
      * If new entry's version is not higher then previous, update will be cancelled.
      */
@@ -124,6 +130,10 @@ public final class CacheEnvironment {
 
     public static int getDefaultCacheTimeoutInMillis() {
         return DEFAULT_CACHE_TIMEOUT;
+    }
+
+    public static boolean getShouldFallback(final Map<String, Object> props) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.FALLBACK, props, false);
     }
 
     public static int getLockTimeoutInMillis(final Properties props) {

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccessImpl.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastStorageAccessImpl.java
@@ -23,7 +23,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * StorageAccess implementation wrapping a Hazelcast {@link RegionCache} reference.
@@ -121,7 +120,8 @@ public class HazelcastStorageAccessImpl implements HazelcastStorageAccess {
     @Override
     public void release() {
         try {
-            delegate.destroy(); // TODO why noop was here?
+            // TODO why noop was here?
+            delegate.destroy();
         } catch (Exception e) {
             if (fallback) {
                 Logger.getLogger(HazelcastStorageAccessImpl.class).finest(e.getMessage(), e);


### PR DESCRIPTION
In order to effectively implement a failover, we have a few options to choose from. 

The first of them and probably the least hacky approach is to allow the second-level cache access, but whenever encountering a connection issue, default to either NOOP or act as the value is not present in the cache.

This approach can be potentially improved by verifying if a client is connected before even attempting to call its methods.

TODO:
- [ ] narrow exception types for failover scenarios
- [ ] handle `OperationTimeoutException` separately for each operation
- [x] investigate cluster-based timestamping and its implementation in 5.3 + provide failover
- [ ] change client defaults to trying to connect indefinitely instead of shutting down after some time (https://github.com/hazelcast/hazelcast-hibernate5/pull/145)
- [ ] decide on the fallback strategy for `afterUpdate` and `unlockItem` methods
- [ ] decide which local timestamper to use `Clock.currentTimeMillis()` vs `SimpleTimestamper.next()`

---- 
closes https://github.com/hazelcast/hazelcast-hibernate5/issues/144