### PR TITLE
Increase cluster connection timeout and make it configurable

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -18,8 +18,10 @@ package com.hazelcast.hibernate;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.config.ConfigurationException;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
+import java.time.Duration;
 import java.util.Properties;
 
 /**
@@ -63,6 +65,11 @@ public final class CacheEnvironment {
      * Property to configure if the HazelcastInstance should going to shutdown when the RegionFactory is being stopped
      */
     public static final String SHUTDOWN_ON_STOP = "hibernate.cache.hazelcast.shutdown_on_session_factory_close";
+
+    /**
+     * Property to configure the IMDG cluster connection timeout
+     */
+    public static final String CLUSTER_TIMEOUT = "hibernate.cache.hazelcast.cluster_timeout";
 
     /**
      * Property to configure the timeout delay before a lock eventually times out
@@ -124,6 +131,14 @@ public final class CacheEnvironment {
 
     public static int getDefaultCacheTimeoutInMillis() {
         return DEFAULT_CACHE_TIMEOUT;
+    }
+
+    public static Duration getClusterTimeout(final Properties props) {
+        int timeoutMillis = ConfigurationHelper.getInt(CLUSTER_TIMEOUT, props, Integer.MAX_VALUE);
+        if (timeoutMillis <= 0) {
+            throw new ConfigurationException("Invalid cluster timeout [" + timeoutMillis + "]");
+        }
+        return Duration.ofMillis(timeoutMillis);
     }
 
     public static int getLockTimeoutInMillis(final Properties props) {

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -51,6 +51,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
         String clientClusterName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, props, null);
         String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+        long clusterTimeout = CacheEnvironment.getClusterTimeout(props).toMillis();
 
         if (configResourcePath != null) {
             try {
@@ -77,6 +78,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(clusterTimeout);
     }
 
     @Override

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -18,8 +18,10 @@ package com.hazelcast.hibernate;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.StringHelper;
+import org.hibernate.internal.util.config.ConfigurationException;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
+import java.time.Duration;
 import java.util.Properties;
 
 /**
@@ -63,6 +65,11 @@ public final class CacheEnvironment {
      * Property to configure if the HazelcastInstance should going to shutdown when the RegionFactory is being stopped
      */
     public static final String SHUTDOWN_ON_STOP = "hibernate.cache.hazelcast.shutdown_on_session_factory_close";
+
+    /**
+     * Property to configure the IMDG cluster connection timeout
+     */
+    public static final String CLUSTER_TIMEOUT = "hibernate.cache.hazelcast.cluster_timeout";
 
     /**
      * Property to configure the timeout delay before a lock eventually times out
@@ -124,6 +131,14 @@ public final class CacheEnvironment {
 
     public static int getDefaultCacheTimeoutInMillis() {
         return DEFAULT_CACHE_TIMEOUT;
+    }
+
+    public static Duration getClusterTimeout(final Properties props) {
+        int timeoutMillis = ConfigurationHelper.getInt(CLUSTER_TIMEOUT, props, Integer.MAX_VALUE);
+        if (timeoutMillis <= 0) {
+            throw new ConfigurationException("Invalid cluster timeout [" + timeoutMillis + "]");
+        }
+        return Duration.ofMillis(timeoutMillis);
     }
 
     public static int getLockTimeoutInMillis(final Properties props) {

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -51,6 +51,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
         String clientClusterName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, props, null);
         String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+        long clusterTimeout = CacheEnvironment.getClusterTimeout(props).toMillis();
 
         if (configResourcePath != null) {
             try {
@@ -77,6 +78,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(clusterTimeout);
     }
 
     @Override

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -15,7 +15,6 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.logging.Logger;
 import org.hibernate.cfg.Environment;
 import org.hibernate.internal.util.StringHelper;
 import org.hibernate.internal.util.config.ConfigurationException;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -51,6 +51,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
         String clientClusterName = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, props, null);
         String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+        long clusterTimeout = CacheEnvironment.getClusterTimeout(props).toMillis();
 
         if (configResourcePath != null) {
             try {
@@ -77,6 +78,7 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setInitialBackoffMillis(INITIAL_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMaxBackoffMillis(MAX_BACKOFF_MS);
         clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setMultiplier(BACKOFF_MULTIPLIER);
+        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig().setClusterConnectTimeoutMillis(clusterTimeout);
     }
 
     @Override


### PR DESCRIPTION
By default, IMDG client doesn't try to reconnect to a cluster indefinitely which results in a necessity of restarting applications after longer disconnection periods.

Changed the cluster connection timeout to effectively "never" so that it recovers shortly after cluster goes back online; made it configurable.

----
Related: https://github.com/hazelcast/hazelcast-hibernate5/issues/144