### PR TITLE
Use atomic timestamp for sensitive tests.

### DIFF
--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -17,6 +17,7 @@ package com.hazelcast.hibernate;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.local.AtomicTimedLocalCacheRegionFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -42,7 +43,7 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
 
     protected Properties getCacheProperties() {
         Properties props = new Properties();
-        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        props.setProperty(Environment.CACHE_REGION_FACTORY, AtomicTimedLocalCacheRegionFactory.class.getName());
         return props;
     }
 

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/AtomicTimedLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/AtomicTimedLocalCacheRegionFactory.java
@@ -1,0 +1,34 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.HazelcastLocalCacheRegionFactory;
+import org.hibernate.cache.spi.CacheKeysFactory;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This class just extends HazelcastLocalCacheRegionFactory to ensure that consecutive timestamps are
+ * different and in an increasing manner. Cluster#getClusterTime() may fall short to provide different
+ * timestamps when it is called repeatedly and in such a case test results become inconsistent.
+ */
+public class AtomicTimedLocalCacheRegionFactory extends HazelcastLocalCacheRegionFactory {
+
+    private final AtomicLong epoch = new AtomicLong(1);
+
+    public AtomicTimedLocalCacheRegionFactory() {
+        super();
+    }
+
+    public AtomicTimedLocalCacheRegionFactory(final CacheKeysFactory cacheKeysFactory) {
+        super(cacheKeysFactory);
+    }
+
+    public AtomicTimedLocalCacheRegionFactory(final HazelcastInstance instance) {
+        super(instance);
+    }
+
+    @Override
+    public long nextTimestamp() {
+        return epoch.getAndIncrement();
+    }
+}


### PR DESCRIPTION
As discussed in #126, millisecond resolution may fall short when updates are frequent. This behavior can be tolerable in deployments since the cache will restore itself after a cache miss. However in test environment this makes some tests inconsistent. This will not be the case anymore when the new factory is used. 

- [X] Signed Contributor Agreement
