### PR TITLE
Fix native client test

### DIFF
--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -15,23 +15,15 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.instance.HazelcastAccessor;
-import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
@@ -42,12 +34,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import java.util.Date;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.isA;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -57,45 +47,6 @@ public class CustomPropertiesTest extends HibernateTestSupport {
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
-
-    @Test
-    public void testNativeClient() throws Exception {
-        TestHazelcastFactory factory = new TestHazelcastFactory();
-        Config config = new ClasspathXmlConfig("hazelcast-custom.xml");
-        HazelcastInstance main = factory.newHazelcastInstance(config);
-        Properties props = getDefaultProperties();
-        props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
-        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
-        props.setProperty(CacheEnvironment.USE_NATIVE_CLIENT, "true");
-        props.setProperty(CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME, "dev-custom");
-        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
-        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
-        loader.configure(props);
-        loader.setInstanceFactory(factory);
-        SessionFactory sf = createSessionFactory(props, loader);
-        final HazelcastInstance hz = HazelcastAccessor.getHazelcastInstance(sf);
-        assertTrue(hz instanceof HazelcastClientProxy);
-        assertEquals(1, main.getCluster().getMembers().size());
-        HazelcastClientProxy client = (HazelcastClientProxy) hz;
-        ClientConfig clientConfig = client.getClientConfig();
-        assertEquals("dev-custom", clientConfig.getClusterName());
-        assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
-        assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
-        factory.newHazelcastInstance(config);
-        assertEquals(2, hz.getCluster().getMembers().size());
-        main.shutdown();
-
-        assertTrueEventually(() -> assertEquals(1, hz.getCluster().getMembers().size()));
-
-        assertEquals(1, hz.getCluster().getMembers().size());
-        Session session = sf.openSession();
-        Transaction tx = session.beginTransaction();
-        session.save(new DummyEntity(1L, "dummy", 0, new Date()));
-        tx.commit();
-        session.close();
-        sf.close();
-        factory.shutdownAll();
-    }
 
     @Test
     public void testNamedInstance() {
@@ -205,10 +156,4 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         sf.close();
     }
 
-    private Properties getDefaultProperties() {
-        Properties props = new Properties();
-        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
-        props.setProperty(CacheEnvironment.CONFIG_FILE_PATH_LEGACY, "hazelcast-custom.xml");
-        return props;
-    }
 }


### PR DESCRIPTION
Fixes the [test failure](https://github.com/hazelcast/hazelcast-hibernate5/issues/30#issuecomment-623319465) occurs only in hazelcast-hibernate5 module. 