### PR TITLE
Hazelcast Client failover with asynchronous reconnect

### DIFF
--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -73,11 +73,11 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     public DomainDataRegion buildDomainDataRegion(final DomainDataRegionConfig regionConfig,
                                                   final DomainDataRegionBuildingContext buildingContext) {
         return new HazelcastDomainDataRegionImpl(
-                regionConfig,
-                this,
-                createDomainDataStorageAccess(regionConfig, buildingContext),
-                cacheKeysFactory,
-                buildingContext
+          regionConfig,
+          this,
+          createDomainDataStorageAccess(regionConfig, buildingContext),
+          cacheKeysFactory,
+          buildingContext
         );
     }
 
@@ -89,7 +89,8 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     protected DomainDataStorageAccess createDomainDataStorageAccess(final DomainDataRegionConfig regionConfig,
                                                                     final DomainDataRegionBuildingContext buildingContext) {
         return new HazelcastStorageAccessImpl(
-                createRegionCache(regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig)
+          createRegionCache(regionConfig.getRegionName(), buildingContext.getSessionFactory(), regionConfig),
+          CacheEnvironment.getFallback(buildingContext.getSessionFactory().getProperties())
         );
     }
 
@@ -100,7 +101,8 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         // queries
         final LocalRegionCache regionCache = new LocalRegionCache(this, regionName, instance, null, false);
         cleanupService.registerCache(regionCache);
-        return new HazelcastStorageAccessImpl(regionCache);
+        return new HazelcastStorageAccessImpl(regionCache, CacheEnvironment
+          .getFallback(sessionFactory.getProperties()));
     }
 
     protected abstract RegionCache createRegionCache(final String unqualifiedRegionName,
@@ -111,8 +113,8 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     protected StorageAccess createTimestampsRegionStorageAccess(final String regionName,
                                                                 final SessionFactoryImplementor sessionFactory) {
         return new HazelcastStorageAccessImpl(
-                createTimestampsRegionCache(regionName, sessionFactory)
-        );
+          createTimestampsRegionCache(regionName, sessionFactory),
+          CacheEnvironment.getFallback(sessionFactory.getProperties()));
     }
 
     protected abstract RegionCache createTimestampsRegionCache(final String regionName,
@@ -146,7 +148,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
             final ClassLoader cl = Thread.currentThread().getContextClassLoader();
             try {
                 final Class<IHazelcastInstanceFactory> factory =
-                        (Class<IHazelcastInstanceFactory>) Class.forName(factoryName, true, cl);
+                  (Class<IHazelcastInstanceFactory>) Class.forName(factoryName, true, cl);
                 instanceLoader = factory.newInstance().createInstanceLoader(toProperties(configValues));
             } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
                 throw new CacheException("Failed to set up hazelcast instance factory", e);

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -106,11 +106,6 @@ public final class CacheEnvironment {
     public static final String HAZELCAST_INSTANCE_NAME = "hibernate.cache.hazelcast.instance_name";
 
     /**
-     * Property to configure the Hazelcast operation timeout
-     */
-    public static final String HAZELCAST_OPERATION_TIMEOUT = "hazelcast.operation.call.timeout.millis";
-
-    /**
      * Property to configure Hazelcast Shutdown Hook
      */
     public static final String HAZELCAST_SHUTDOWN_HOOK_ENABLED = "hazelcast.shutdownhook.enabled";

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -22,6 +22,7 @@ import org.hibernate.internal.util.config.ConfigurationException;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Properties;
 
 import static java.lang.String.format;
@@ -68,6 +69,11 @@ public final class CacheEnvironment {
      * Property to configure if the HazelcastInstance should going to shutdown when the RegionFactory is being stopped
      */
     public static final String SHUTDOWN_ON_STOP = "hibernate.cache.hazelcast.shutdown_on_session_factory_close";
+
+    /**
+     * Property to enable fallback on datasource if Hazelcast cluster is not available
+     */
+    public static final String FALLBACK = "hibernate.cache.hazelcast.fallback";
 
     /**
      * Property to configure the IMDG cluster connection timeout
@@ -200,5 +206,9 @@ public final class CacheEnvironment {
             throw new ConfigurationException("Invalid cluster timeout [" + timeoutMillis + "]");
         }
         return Duration.ofMillis(timeoutMillis);
+    }
+
+    public static boolean getFallback(final Map<String, Object> props) {
+        return ConfigurationHelper.getBoolean(CacheEnvironment.FALLBACK, props, true);
     }
 }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -72,8 +72,8 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
     }
 
     public long nextTimestamp() {
-        long result = instance == null ? Clock.currentTimeMillis()
-                : HazelcastTimestamper.nextTimestamp(instance);
-        return result;
+        return instance == null
+          ? Clock.currentTimeMillis()
+          : HazelcastTimestamper.nextTimestamp(instance);
     }
 }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -15,18 +15,13 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.Logger;
 
 /**
  * Helper class to create timestamps and calculate timeouts based on either Hazelcast
  * configuration of by requesting values on the cluster.
  */
 public final class HazelcastTimestamper {
-
-    private static final int SEC_TO_MS = 1000;
 
     private HazelcastTimestamper() {
     }
@@ -40,34 +35,5 @@ public final class HazelcastTimestamper {
 
         // System time in ms.
         return instance.getCluster().getClusterTime();
-    }
-
-    public static int getTimeout(final HazelcastInstance instance, final String regionName) {
-        try {
-            final MapConfig cfg = instance.getConfig().findMapConfig(regionName);
-            if (cfg.getTimeToLiveSeconds() > 0) {
-                // TTL in ms
-                return cfg.getTimeToLiveSeconds() * SEC_TO_MS;
-            }
-        } catch (UnsupportedOperationException e) {
-            // HazelcastInstance is instance of HazelcastClient.
-            Logger.getLogger(HazelcastTimestamper.class).finest(e);
-        }
-        return CacheEnvironment.getDefaultCacheTimeoutInMillis();
-    }
-
-    public static long getMaxOperationTimeout(final HazelcastInstance instance) {
-        String maxOpTimeoutProp = null;
-        try {
-            Config config = instance.getConfig();
-            maxOpTimeoutProp = config.getProperty(CacheEnvironment.HAZELCAST_OPERATION_TIMEOUT);
-        } catch (UnsupportedOperationException e) {
-            // HazelcastInstance is instance of HazelcastClient.
-            Logger.getLogger(HazelcastTimestamper.class).finest(e);
-        }
-        if (maxOpTimeoutProp != null) {
-            return Long.parseLong(maxOpTimeoutProp);
-        }
-        return Long.MAX_VALUE;
     }
 }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -17,6 +17,7 @@ package com.hazelcast.hibernate.instance;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientConnectionStrategyConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
@@ -64,18 +65,18 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
             clientConfig.getNetworkConfig().addAddress(address);
         }
 
-        clientConfig.getNetworkConfig().setSmartRouting(true);
-        clientConfig.getNetworkConfig().setRedoOperation(true);
+        clientConfig.getNetworkConfig()
+          .setSmartRouting(true)
+          .setRedoOperation(true);
 
         // By default, try to connect a cluster with intervals starting with 2 sec and multiplied by 1.5
         // at each step with max backoff of 35 seconds
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
-          .setInitialBackoffMillis((int) CacheEnvironment.getInitialBackoff(props).toMillis());
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
-          .setMaxBackoffMillis((int) CacheEnvironment.getMaxBackoff(props).toMillis());
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
-          .setMultiplier(CacheEnvironment.getBackoffMultiplier(props));
-        clientConfig.getConnectionStrategyConfig().getConnectionRetryConfig()
+        clientConfig.getConnectionStrategyConfig()
+          .setReconnectMode(ClientConnectionStrategyConfig.ReconnectMode.ASYNC)
+          .getConnectionRetryConfig()
+          .setInitialBackoffMillis((int) CacheEnvironment.getInitialBackoff(props).toMillis())
+          .setMaxBackoffMillis((int) CacheEnvironment.getMaxBackoff(props).toMillis())
+          .setMultiplier(CacheEnvironment.getBackoffMultiplier(props))
           .setClusterConnectTimeoutMillis(CacheEnvironment.getClusterTimeout(props).toMillis());
     }
 

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -17,12 +17,9 @@ package com.hazelcast.hibernate.instance;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientConnectionStrategyConfig;
-import com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.hibernate.CacheEnvironment;
 import org.hibernate.cache.CacheException;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 
@@ -31,8 +28,14 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.*;
-import static com.hazelcast.hibernate.CacheEnvironment.*;
+import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.ASYNC;
+import static com.hazelcast.client.config.ClientConnectionStrategyConfig.ReconnectMode.ON;
+import static com.hazelcast.hibernate.CacheEnvironment.NATIVE_CLIENT_ADDRESS;
+import static com.hazelcast.hibernate.CacheEnvironment.NATIVE_CLIENT_CLUSTER_NAME;
+import static com.hazelcast.hibernate.CacheEnvironment.NATIVE_CLIENT_INSTANCE_NAME;
+import static com.hazelcast.hibernate.CacheEnvironment.getBackoffMultiplier;
+import static com.hazelcast.hibernate.CacheEnvironment.getClusterTimeout;
+import static com.hazelcast.hibernate.CacheEnvironment.getConfigFilePath;
 import static com.hazelcast.hibernate.CacheEnvironment.getFallback;
 import static com.hazelcast.hibernate.CacheEnvironment.getInitialBackoff;
 import static com.hazelcast.hibernate.CacheEnvironment.getMaxBackoff;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -75,7 +75,7 @@ class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
             if (instance == null) {
                 throw new CacheException("No instance with name [" + existingInstanceName + "] could be found.");
             }
-        } else  {
+        } else {
             instance = Hazelcast.newHazelcastInstance(config);
         }
         return instance;
@@ -88,8 +88,8 @@ class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
         }
         if (!shutDown) {
             LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
-                    + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
-                    + CacheEnvironment.HAZELCAST_SHUTDOWN_HOOK_ENABLED + " property!)");
+              + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+              + CacheEnvironment.HAZELCAST_SHUTDOWN_HOOK_ENABLED + " property!)");
             return;
         }
         try {

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/NativeClientFailoverTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/NativeClientFailoverTest.java
@@ -1,0 +1,78 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class NativeClientFailoverTest extends HibernateSlowTestSupport {
+
+    protected SessionFactory clientSf;
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        clientSf = createClientSessionFactory(getCacheProperties());
+    }
+
+    @Test(timeout = 2000)
+    public void shouldBypassCacheWhenClientDisconnected() {
+        Session session = clientSf.openSession();
+
+        Hazelcast.shutdownAll();
+
+        Transaction tx = session.beginTransaction();
+        DummyEntity e = new DummyEntity(1, "dummy:1", 123456d, new Date());
+        session.save(e);
+        tx.commit();
+        session.close();
+
+        session = clientSf.openSession();
+        DummyEntity retrieved = session.get(DummyEntity.class, (long) 1);
+        assertEquals("dummy:1", retrieved.getName());
+    }
+
+    @After
+    public void tearDown() {
+        if (clientSf != null) {
+            clientSf.close();
+        }
+    }
+
+    protected SessionFactory createClientSessionFactory(Properties props) {
+        Configuration conf = new Configuration();
+        conf.configure(HibernateTestSupport.class.getClassLoader().getResource("test-hibernate-client.cfg.xml"));
+        addHbmMappings(conf);
+        conf.addProperties(props);
+
+        final SessionFactory sf = conf.buildSessionFactory();
+        sf.getStatistics().setStatisticsEnabled(true);
+
+        return sf;
+    }
+}

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/NativeClientFailoverTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/NativeClientFailoverTest.java
@@ -40,7 +40,7 @@ public class NativeClientFailoverTest extends HibernateSlowTestSupport {
         clientSf = createClientSessionFactory(getCacheProperties());
     }
 
-    @Test(timeout = 2000)
+    @Test(timeout = 5000)
     public void shouldBypassCacheWhenClientDisconnected() {
         Session session = clientSf.openSession();
 
@@ -70,9 +70,6 @@ public class NativeClientFailoverTest extends HibernateSlowTestSupport {
         addHbmMappings(conf);
         conf.addProperties(props);
 
-        final SessionFactory sf = conf.buildSessionFactory();
-        sf.getStatistics().setStatisticsEnabled(true);
-
-        return sf;
+        return conf.buildSessionFactory();
     }
 }


### PR DESCRIPTION
####  Background:

There are two problems with the current implementation:
- after a few recovery attempts, the client shuts itself down permanently which forces an application to be restarted to regain an IMDG connection (solved partially by https://github.com/hazelcast/hazelcast-hibernate5/pull/145)
- if the client is disconnected, `hazelcast-hibernate` doesn't always fall back onto a datasource
- all client operations don't fail-fast but wait for the reconnection which often results in multiple seconds of extra latency

In order to not sacrifice resiliency, a failover mechanism with background reconnect was implemented.

Setting `hibernate.cache.hazelcast.fallback` to _false_ brings back the old behaviour, should someone need it.


----
Related: https://github.com/hazelcast/hazelcast-hibernate5/pull/145
Closes: https://github.com/hazelcast/hazelcast-hibernate5/issues/144