### PR TITLE
Align behaviour of read-only strategy implementations

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -38,13 +38,14 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
     }
 
     /**
-     * @throws UnsupportedOperationException
+     *
+     * @throws UnsupportedOperationException can't update readonly object
      */
     @Override
     public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
                                final Object previousVersion, final SoftLock lock) throws CacheException {
-        throw new UnsupportedOperationException("Cannot update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.finest("Illegal attempt to update item cached as read-only [" + key + "]");
+        throw new UnsupportedOperationException("Can't write to a readonly object");
     }
 
     /**
@@ -62,13 +63,9 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
         return null;
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public SoftLock lockRegion() throws CacheException {
-        throw new UnsupportedOperationException("Attempting to lock a read-only cache region: "
-                + getHazelcastRegion().getName());
+        return null;
     }
 
     @Override
@@ -95,16 +92,17 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
      */
     @Override
     public void unlockRegion(final SoftLock lock) throws CacheException {
-        log.warning("Attempting to unlock a read-only cache region");
+        cache.clear();
     }
 
     /**
-     * @throws UnsupportedOperationException
+     *
+     * @throws UnsupportedOperationException can't update readonly object
      */
     @Override
     public boolean update(final Object key, final Object value, final Object currentVersion,
                           final Object previousVersion) throws CacheException {
-        throw new UnsupportedOperationException("Attempting to update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.finest("Illegal attempt to update item cached as read-only [" + key + "]");
+        throw new UnsupportedOperationException("Can't update readonly object");
     }
 }

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -17,6 +17,7 @@ package com.hazelcast.hibernate;
 
 import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.logging.NoLogFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -73,10 +74,19 @@ public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
         assertEquals(10, dummyEntityCacheStats.getMissCount());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testUpdateQueryCausesInvalidationOfEntireRegion() {
         insertDummyEntities(10);
-        executeUpdateQuery("UPDATE DummyEntity set name = 'manually-updated' where id=2");
+
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+
+        sf.getStatistics().clear();
+
+        getDummyEntities(sf, 10);
+
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+        assertEquals(0, dummyEntityCacheStats.getHitCount());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -89,16 +99,24 @@ public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
     public void testAfterUpdateShouldThrowOnReadOnly() {
         HazelcastRegion hzRegion = mock(HazelcastRegion.class);
         when(hzRegion.getCache()).thenReturn(null);
-        when(hzRegion.getLogger()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(new NoLogFactory().getLogger(""));
         ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
         readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testUpdateQueryCausesInvalidationOfEntireCollectionRegion() {
         insertDummyEntities(1, 10);
 
-        //attempt to evict properties reference in DummyEntity because of custom SQL query on Collection region
-        executeUpdateQuery("update DummyProperty ent set ent.key='manually-updated'");
+        //properties reference in DummyEntity is evicted because of custom SQL query on Collection region
+        executeUpdateQuery(sf, "update DummyProperty ent set ent.key='manually-updated'");
+        sf.getStatistics().clear();
+
+        //property reference missed in cache.
+        getPropertiesOfEntity(0);
+
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY + ".properties");
+        assertEquals(0, dummyPropertyCacheStats.getHitCount());
+        assertEquals(1, dummyPropertyCacheStats.getMissCount());
     }
 }

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
@@ -79,67 +79,6 @@ public class TopicReadOnlyTest extends TopicReadOnlyTestSupport {
         assertTopicNotifications(67, getTimestampsRegionName());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntities() {
-        insertDummyEntities(1, 10);
-
-        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntitiesAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntityAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
     protected AccessType getCacheStrategy() {
         return AccessType.READ_ONLY;
     }

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/access/ReadOnlyAccessDelegate.java
@@ -38,13 +38,14 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
     }
 
     /**
-     * @throws UnsupportedOperationException
+     *
+     * @throws UnsupportedOperationException can't update readonly object
      */
     @Override
     public boolean afterUpdate(final Object key, final Object value, final Object currentVersion,
                                final Object previousVersion, final SoftLock lock) throws CacheException {
-        throw new UnsupportedOperationException("Cannot update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.finest("Illegal attempt to update item cached as read-only [" + key + "]");
+        throw new UnsupportedOperationException("Can't write to a readonly object");
     }
 
     /**
@@ -62,13 +63,9 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
         return null;
     }
 
-    /**
-     * @throws UnsupportedOperationException
-     */
     @Override
     public SoftLock lockRegion() throws CacheException {
-        throw new UnsupportedOperationException("Attempting to lock a read-only cache region: "
-                + getHazelcastRegion().getName());
+        return null;
     }
 
     @Override
@@ -95,16 +92,17 @@ public class ReadOnlyAccessDelegate<T extends HazelcastRegion> extends NonStrict
      */
     @Override
     public void unlockRegion(final SoftLock lock) throws CacheException {
-        log.warning("Attempting to unlock a read-only cache region");
+        cache.clear();
     }
 
     /**
-     * @throws UnsupportedOperationException
+     *
+     * @throws UnsupportedOperationException can't update readonly object
      */
     @Override
     public boolean update(final Object key, final Object value, final Object currentVersion,
                           final Object previousVersion) throws CacheException {
-        throw new UnsupportedOperationException("Attempting to update an item in a read-only cache: "
-                + getHazelcastRegion().getName());
+        log.finest("Illegal attempt to update item cached as read-only [" + key + "]");
+        throw new UnsupportedOperationException("Can't update readonly object");
     }
 }

--- a/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
+++ b/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/TopicReadOnlyTest.java
@@ -79,67 +79,6 @@ public class TopicReadOnlyTest extends TopicReadOnlyTestSupport {
         assertTopicNotifications(67, getTimestampsRegionName());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntities() {
-        insertDummyEntities(1, 10);
-
-        executeUpdateQuery("update DummyEntity set name = 'updated-name' where id < 2");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateEntitiesAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id < 2");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUpdateOneEntityAndProperties() {
-        insertDummyEntities(1, 10);
-
-        Session session = null;
-        Transaction txn = null;
-        try {
-            session = sf.openSession();
-            txn = session.beginTransaction();
-            Query query = session.createQuery("update DummyEntity set name = 'updated-name' where id = 0");
-            query.setCacheable(true);
-            query.executeUpdate();
-
-            Query query2 = session.createQuery("update DummyProperty set version = version + 1");
-            query2.setCacheable(true);
-            query2.executeUpdate();
-
-            txn.commit();
-        } catch (RuntimeException e) {
-            txn.rollback();
-            e.printStackTrace();
-            throw e;
-        } finally {
-            session.close();
-        }
-    }
-
     protected AccessType getCacheStrategy() {
         return AccessType.READ_ONLY;
     }


### PR DESCRIPTION
_Read-Only_ access strategies were behaving differently across various versions of `hazelcast-hibernate`.

This involved things like:
- throwing vs. not-throwing exceptions when trying to lock a region
- no-op vs. invalidation of the entire region when trying to unlock a region

Aligned them to the implementation provided by the Hibernate 5.3, including exception messages and logs.

----

fixes: https://github.com/hazelcast/hazelcast-hibernate5/issues/29