### PR TITLE
Improve ExtendedStatisticsSupport for IMapRegionCache

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -15,16 +15,16 @@
 
 package com.hazelcast.hibernate.distributed;
 
-import com.hazelcast.core.EntryView;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.hibernate.CacheEnvironment;
 import com.hazelcast.hibernate.HazelcastTimestamper;
 import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.serialization.Expirable;
-import com.hazelcast.hibernate.serialization.MarkerWrapper;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
+import com.hazelcast.hibernate.serialization.MarkerWrapper;
 import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.map.IMap;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.access.SoftLock;
 
@@ -59,6 +59,7 @@ public class IMapRegionCache implements RegionCache {
     private final int lockTimeout;
     private final long tryLockAndGetTimeout;
     private final AtomicLong markerIdCounter;
+    private final boolean isMember;
 
     public IMapRegionCache(final String name, final HazelcastInstance hazelcastInstance,
                            final Properties props, final CacheDataDescription metadata) {
@@ -66,6 +67,7 @@ public class IMapRegionCache implements RegionCache {
         this.hazelcastInstance = hazelcastInstance;
         this.versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
         this.map = hazelcastInstance.getMap(this.name);
+        this.isMember = isMemberInstance(hazelcastInstance);
         lockTimeout = CacheEnvironment.getLockTimeoutInMillis(props);
         final long maxOperationTimeout = HazelcastTimestamper.getMaxOperationTimeout(hazelcastInstance);
         tryLockAndGetTimeout = Math.min(maxOperationTimeout, COMPARISON_VALUE);
@@ -156,16 +158,13 @@ public class IMapRegionCache implements RegionCache {
         return map.size();
     }
 
+    /**
+     * Returns the total in-memory cost in bytes (including IMap, Near Cache, backup, Merkle trees)
+     * or -1 if using Hazelcast Client
+     */
     @Override
     public long getSizeInMemory() {
-        long size = 0;
-        for (final Object key : map.keySet()) {
-            final EntryView entry = map.getEntryView(key);
-            if (entry != null) {
-                size += entry.getCost();
-            }
-        }
-        return size;
+        return isMember ? map.getLocalMapStats().getHeapCost() : -1;
     }
 
     @Override
@@ -177,4 +176,7 @@ public class IMapRegionCache implements RegionCache {
         return hazelcastInstance.getLocalEndpoint().getUuid().toString() + markerIdCounter.getAndIncrement();
     }
 
+    private static boolean isMemberInstance(HazelcastInstance instance) {
+        return instance.getLocalEndpoint() instanceof Member;
+    }
 }

--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -160,6 +160,7 @@ public class IMapRegionCache implements RegionCache {
 
     /**
      * Returns the total in-memory cost in bytes (including IMap, Near Cache, backup, Merkle trees)
+     * for a particular application instance
      * or -1 if using Hazelcast Client
      */
     @Override

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -160,6 +160,7 @@ public class IMapRegionCache implements RegionCache {
 
     /**
      * Returns the total in-memory cost in bytes (including IMap, Near Cache, backup, Merkle trees)
+     * for a particular application instance
      * or -1 if using Hazelcast Client
      */
     @Override

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -15,7 +15,7 @@
 
 package com.hazelcast.hibernate.distributed;
 
-import com.hazelcast.core.EntryView;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.CacheEnvironment;
 import com.hazelcast.hibernate.HazelcastTimestamper;
@@ -59,6 +59,7 @@ public class IMapRegionCache implements RegionCache {
     private final int lockTimeout;
     private final long tryLockAndGetTimeout;
     private final AtomicLong markerIdCounter;
+    private final boolean isMember;
 
     public IMapRegionCache(final String name, final HazelcastInstance hazelcastInstance,
                            final Properties props, final CacheDataDescription metadata) {
@@ -66,6 +67,7 @@ public class IMapRegionCache implements RegionCache {
         this.hazelcastInstance = hazelcastInstance;
         this.versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
         this.map = hazelcastInstance.getMap(this.name);
+        this.isMember = isMemberInstance(hazelcastInstance);
         lockTimeout = CacheEnvironment.getLockTimeoutInMillis(props);
         final long maxOperationTimeout = HazelcastTimestamper.getMaxOperationTimeout(hazelcastInstance);
         tryLockAndGetTimeout = Math.min(maxOperationTimeout, COMPARISON_VALUE);
@@ -156,16 +158,13 @@ public class IMapRegionCache implements RegionCache {
         return map.size();
     }
 
+    /**
+     * Returns the total in-memory cost in bytes (including IMap, Near Cache, backup, Merkle trees)
+     * or -1 if using Hazelcast Client
+     */
     @Override
     public long getSizeInMemory() {
-        long size = 0;
-        for (final Object key : map.keySet()) {
-            final EntryView entry = map.getEntryView(key);
-            if (entry != null) {
-                size += entry.getCost();
-            }
-        }
-        return size;
+        return isMember ? map.getLocalMapStats().getHeapCost() : -1;
     }
 
     @Override
@@ -177,4 +176,7 @@ public class IMapRegionCache implements RegionCache {
         return hazelcastInstance.getLocalEndpoint().getUuid().toString() + markerIdCounter.getAndIncrement();
     }
 
+    private static boolean isMemberInstance(HazelcastInstance instance) {
+        return instance.getLocalEndpoint() instanceof Member;
+    }
 }

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/RegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/RegionCache.java
@@ -43,9 +43,14 @@ public interface RegionCache extends Region, ExtendedStatisticsSupport {
 
     Object get(final Object key, final long txTimestamp);
 
+    /**
+     * Hazelcast does not support pushing elements to disk.
+     *
+     * @return -1 this value means "unsupported"
+     */
     @Override
     default long getElementCountOnDisk() {
-        return 0;
+        return -1;
     }
 
     default long nextTimestamp() {

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -81,7 +81,8 @@ public class IMapRegionCache implements RegionCache {
     }
 
     /**
-     * Returns the number of in-memory entries (without backups) or -1 if using Hazelcast Client
+     * Returns the number of in-memory entries (without backups) for a particular application instance
+     * or -1 if using Hazelcast Client
      */
     @Override
     public long getElementCountInMemory() {
@@ -100,6 +101,7 @@ public class IMapRegionCache implements RegionCache {
 
     /**
      * Returns the total in-memory cost in bytes (including IMap, Near Cache, backup, Merkle trees)
+     * for a particular application instance
      * or -1 if using Hazelcast Client
      */
     @Override

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -15,12 +15,12 @@
 
 package com.hazelcast.hibernate.distributed;
 
-import com.hazelcast.core.EntryView;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.Value;
+import com.hazelcast.map.IMap;
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.SoftLock;
 
@@ -42,12 +42,15 @@ public class IMapRegionCache implements RegionCache {
     private final IMap<Object, Expirable> map;
     private final String name;
     private final RegionFactory regionFactory;
+    private final boolean isMember;
 
-    public IMapRegionCache(final RegionFactory regionFactory, final String name,
-                           final HazelcastInstance hazelcastInstance) {
+    public IMapRegionCache(
+      RegionFactory regionFactory,
+      String name,
+      HazelcastInstance hazelcastInstance) {
         this.name = name;
         this.regionFactory = regionFactory;
-
+        this.isMember = isMemberInstance(hazelcastInstance);
         this.map = hazelcastInstance.getMap(this.name);
     }
 
@@ -77,9 +80,12 @@ public class IMapRegionCache implements RegionCache {
         return entry == null ? null : entry.getValue(txTimestamp);
     }
 
+    /**
+     * Returns the number of in-memory entries (without backups) or -1 if using Hazelcast Client
+     */
     @Override
     public long getElementCountInMemory() {
-        return map.size();
+        return isMember ? map.getLocalMapStats().getOwnedEntryCount() : -1;
     }
 
     @Override
@@ -92,16 +98,13 @@ public class IMapRegionCache implements RegionCache {
         return regionFactory;
     }
 
+    /**
+     * Returns the total in-memory cost in bytes (including IMap, Near Cache, backup, Merkle trees)
+     * or -1 if using Hazelcast Client
+     */
     @Override
     public long getSizeInMemory() {
-        long size = 0;
-        for (final Object key : map.keySet()) {
-            final EntryView entry = map.getEntryView(key);
-            if (entry != null) {
-                size += entry.getCost();
-            }
-        }
-        return size;
+        return isMember ? map.getLocalMapStats().getHeapCost() : -1;
     }
 
     @Override
@@ -114,5 +117,9 @@ public class IMapRegionCache implements RegionCache {
     @Override
     public void unlockItem(final Object key, final SoftLock lock) {
         // no-op
+    }
+
+    private static boolean isMemberInstance(HazelcastInstance instance) {
+        return instance.getLocalEndpoint() instanceof Member;
     }
 }


### PR DESCRIPTION
Local calculation of statistical data by iterating through the whole data set is inefficient and is now replaced with a dedicated solution based on Hazelcast local stats.

In the client-server topology, there are no elements stored in application nodes, hence always returning `-1` to help identify irrelevant metrics.