### PR TITLE
Remove outdated notes about automatic eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ Local region cache eviction can be configured using two parameters:
  - _time-to-live_ - defining the lifespan of cache entries (defaults to 1 hour)
  - -eviction-size_ - defining the maximum cache size (defaults to 100000)
 
-When maximum size is hit, 20% of the entries will be evicted automatically.
-
 Above can be configured in your Hazelcast configuration file:
 
 ```xml

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ On every _Timestamp_ cache update, `hazelcast-hibernate` publishes an invalidati
 
 Local region cache eviction can be configured using two parameters:
  - _time-to-live_ - defining the lifespan of cache entries (defaults to 1 hour)
- - -eviction-size_ - defining the maximum cache size (defaults to 100000)
+ - _eviction-size_ - defining the maximum cache size (defaults to 100000)
 
 Above can be configured in your Hazelcast configuration file:
 


### PR DESCRIPTION
This is no longer true and should be treated as an implementation detail.