### PR TITLE
Ignore invalidation messages for changes made locally

### DIFF
--- a/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate5/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -221,15 +221,7 @@ public class LocalRegionCache implements RegionCache {
     }
 
     protected MessageListener<Object> createMessageListener() {
-        return message -> {
-            // Updates made by current node should have been reflected in its local cache already.
-            // Invalidation is only needed if updates came from other node(s).
-            if (message.getPublishingMember() == null
-                    || hazelcastInstance == null
-                    || !message.getPublishingMember().equals(hazelcastInstance.getCluster().getLocalMember())) {
-                maybeInvalidate(message.getMessageObject());
-            }
-        };
+        return message -> maybeInvalidate(message.getMessageObject());
     }
 
     @Override

--- a/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate5/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,10 +1,13 @@
 package com.hazelcast.hibernate.local;
 
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -12,6 +15,7 @@ import org.hibernate.cache.spi.CacheDataDescription;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
 import java.util.Comparator;
@@ -136,5 +140,44 @@ public class LocalRegionCacheTest {
         verify(instance).getConfig();
         verify(instance).getTopic(eq(CACHE_NAME));
         verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    @Test
+    public void testMessagesFromLocalNodeAreIgnored() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        LocalRegionCache.EvictionConfig evictionConfig = mock(LocalRegionCache.EvictionConfig.class);
+        when(evictionConfig.getTimeToLive()).thenReturn(Duration.ofHours(1));
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        // Create a new local cache
+        new LocalRegionCache(CACHE_NAME, instance, null, true, evictionConfig);
+
+        // Obtain the message listener of the local cache
+        ArgumentCaptor<MessageListener> messageListenerArgumentCaptor = ArgumentCaptor.forClass(MessageListener.class);
+        verify(topic).addMessageListener(messageListenerArgumentCaptor.capture());
+        MessageListener messageListener = messageListenerArgumentCaptor.getValue();
+
+        Message message = mock(Message.class);
+        Member local = mock(Member.class);
+        Cluster cluster = mock(Cluster.class);
+        when(cluster.getLocalMember()).thenReturn(local);
+        when(message.getMessageObject()).thenReturn(new Invalidation());
+        when(message.getPublishingMember()).thenReturn(local);
+        when(instance.getCluster()).thenReturn(cluster);
+
+        // Publish a message from local node
+        messageListener.onMessage(message);
+
+        // Verify that our message listener ignores messages from local node
+        verify(message, never()).getMessageObject();
     }
 }

--- a/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate52/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -111,7 +111,7 @@ public class LocalRegionCache implements RegionCache {
         versionComparator = metadata != null && metadata.isVersioned() ? metadata.getVersionComparator() : null;
         markerIdCounter = new AtomicLong();
 
-        messageListener = createMessageListener();
+        messageListener = ignoreMessagesFromLocalMember(createMessageListener());
         if (withTopic && hazelcastInstance != null) {
             topic = hazelcastInstance.getTopic(name);
             listenerRegistrationId = topic.addMessageListener(messageListener);
@@ -362,6 +362,16 @@ public class LocalRegionCache implements RegionCache {
         return Math.max(evictionConfig.getTimeToLive().toMillis(), 0) == 0
           ? Duration.ofMillis(Integer.MAX_VALUE)
           : evictionConfig.getTimeToLive();
+    }
+
+    private MessageListener<Object> ignoreMessagesFromLocalMember(final MessageListener<Object> delegate) {
+        return message -> {
+            if (message.getPublishingMember() == null
+                    || hazelcastInstance == null
+                    || !message.getPublishingMember().equals(hazelcastInstance.getCluster().getLocalMember())) {
+                delegate.onMessage(message);
+            }
+        };
     }
 
     /**

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,10 +1,13 @@
 package com.hazelcast.hibernate.local;
 
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -15,6 +18,7 @@ import org.hibernate.cache.spi.RegionFactory;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import java.time.Duration;
@@ -176,5 +180,44 @@ public class LocalRegionCacheTest {
         verify(instance).getConfig();
         verify(instance).getTopic(eq(CACHE_NAME));
         verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    @Test
+    public void testMessagesFromLocalNodeAreIgnored() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        LocalRegionCache.EvictionConfig evictionConfig = mock(LocalRegionCache.EvictionConfig.class);
+        when(evictionConfig.getTimeToLive()).thenReturn(Duration.ofHours(1));
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        // Create a new local cache
+        new LocalRegionCache(null, CACHE_NAME, instance, null, true, evictionConfig);
+
+        // Obtain the message listener of the local cache
+        ArgumentCaptor<MessageListener> messageListenerArgumentCaptor = ArgumentCaptor.forClass(MessageListener.class);
+        verify(topic).addMessageListener(messageListenerArgumentCaptor.capture());
+        MessageListener messageListener = messageListenerArgumentCaptor.getValue();
+
+        Message message = mock(Message.class);
+        Member local = mock(Member.class);
+        Cluster cluster = mock(Cluster.class);
+        when(cluster.getLocalMember()).thenReturn(local);
+        when(message.getMessageObject()).thenReturn(new Invalidation());
+        when(message.getPublishingMember()).thenReturn(local);
+        when(instance.getCluster()).thenReturn(cluster);
+
+        // Publish a message from local node
+        messageListener.onMessage(message);
+
+        // Verify that our message listener ignores messages from local node
+        verify(message, never()).getMessageObject();
     }
 }


### PR DESCRIPTION
Hazelcast `LocalRegionCache` currently invalidates cache entries even for changes made by local node. This doesn't seem to be necessary since every single change made locally is already reflected in the local cache.

This unnecessary invalidation is the indirect cause of a stale update we just ran into which can be reproduced by running this simple test: https://github.com/nhanatl/hazelcast-hibernate/blob/test/stale-update-caused-by-unnecessary-invalidation/hazelcast-hibernate52/src/test/java/com/hazelcast/hibernate/EmbeddedCollectionCacheTest.java#L59