### PR TITLE
Replace log4j with reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
         <maven.cobertura.plugin.version>2.0</maven.cobertura.plugin.version>
 
-        <log4j.version>1.2.17</log4j.version>
+        <reload4j.version>1.2.22</reload4j.version>
         <slf4j.api.version>1.7.36</slf4j.api.version>
 
         <junit.version>4.13.2</junit.version>
@@ -301,9 +301,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Replace log4j 1.2.17 with a reload4j 1.2.22 (a drop-in replacement)

Fixes https://github.com/hazelcast/hazelcast-hibernate/security/dependabot/4