### PR TITLE
Make project JDK17 compatible

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11' ]
-        hazelcast: [ '4.1.9','4.2.5' ,'5.0.3', '5.1.3', '5.2-SNAPSHOT' ]
-        hibernate: [ '5.3.28.Final', '5.4.33.Final','5.5.9.Final', '5.6.11.Final' ]
+        java: [ '17' ]
+        hazelcast: [ '4.1.9', '4.2.5', '5.0.3', '5.1.3', '5.2-SNAPSHOT' ]
+        hibernate: [ '5.3.28.Final', '5.4.33.Final', '5.5.9.Final', '5.6.11.Final' ]
     name: Build against Hazelcast ${{ matrix.hazelcast }} and Hibernate ${{ matrix.hibernate }} with JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '8', '11', '17' ]
     name: Build with JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v3.5.0
         with:
-          java-version: 8
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8' ]
         module: [ 'hazelcast-hibernate53' ]
     name: Build ${{ matrix.module }} with JDK ${{ matrix.java }}
     steps:
@@ -38,7 +37,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v3.5.0
         with:
-          java-version: ${{ matrix.java }}
+          java-version:  17
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         module: [ 'hazelcast-hibernate53' ]
-    name: Build ${{ matrix.module }} with JDK ${{ matrix.java }}
+    name: Build ${{ matrix.module }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK

--- a/.github/workflows/compatibility-builds.yml
+++ b/.github/workflows/compatibility-builds.yml
@@ -1,4 +1,4 @@
-name: Build snapshot
+name: Compatiblity Builds
 on:
   schedule:
     - cron: '0 3 * * *'

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -32,6 +32,7 @@
         <javassist.version>3.29.1-GA</javassist.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
+        <jpms.module.name>com.hazelcast.hibernate53</jpms.module.name>
     </properties>
 
     <dependencies>

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/PhoneHomeTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/PhoneHomeTest.java
@@ -5,7 +5,7 @@ import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Map;

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -6,11 +6,11 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
 import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
 import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
@@ -27,7 +27,17 @@ import java.util.Comparator;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -153,7 +163,7 @@ public class LocalRegionCacheTest {
 
         verify(evictionConfig, atLeastOnce()).getMaxSize();
         verify(evictionConfig, atLeastOnce()).getTimeToLive();
-        verifyZeroInteractions(mapConfig);
+        verifyNoInteractions(mapConfig);
     }
 
     // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance
@@ -169,7 +179,7 @@ public class LocalRegionCacheTest {
         when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
 
         ITopic<Object> topic = mock(ITopic.class);
-        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn(UUID.randomUUID());
+        when(topic.addMessageListener(isNotNull())).thenReturn(UUID.randomUUID());
 
         HazelcastInstance instance = mock(HazelcastInstance.class);
         when(instance.getConfig()).thenReturn(config);
@@ -179,7 +189,7 @@ public class LocalRegionCacheTest {
         verify(config).findMapConfig(eq(CACHE_NAME));
         verify(instance).getConfig();
         verify(instance).getTopic(eq(CACHE_NAME));
-        verify(topic).addMessageListener(isNotNull(MessageListener.class));
+        verify(topic).addMessageListener(isNotNull());
     }
 
     @Test

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/local/TimestampsRegionCacheTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.UUID;
 
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -54,9 +54,6 @@ public class TimestampsRegionCacheTest {
         when(mapConfig.getEvictionConfig()).thenReturn(evictionConfig);
         when(mapConfig.getTimeToLiveSeconds()).thenReturn(5);
         when(evictionConfig.getSize()).thenReturn(42);
-
-        // make the message appear that it is coming from a different member of the cluster
-        when(member.localMember()).thenReturn(false);
 
         ArgumentCaptor<MessageListener> listener = ArgumentCaptor.forClass(MessageListener.class);
         when(topic.addMessageListener(listener.capture())).thenReturn(UUID.randomUUID());

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
-        <hazelcast-hibernate.module.name>ALL-UNNAMED</hazelcast-hibernate.module.name>
         <javaModuleArgs/>
 
         <hazelcast.version>5.1.3</hazelcast.version>
@@ -229,6 +228,9 @@
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${jpms.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
@@ -394,9 +396,9 @@
                 <jdk>[9,)</jdk>
             </activation>
             <properties>
-                <!-- required only by Hibernate <5.3 -->
+                <!-- required only for tests with Hibernate <5.3 -->
                 <javaModuleArgs>
-                    --add-opens java.base/java.lang=${hazelcast-hibernate.module.name}
+                    --add-opens java.base/java.lang=ALL-UNNAMED
                     --illegal-access=deny
                 </javaModuleArgs>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
+        <hazelcast-hibernate.module.name>ALL-UNNAMED</hazelcast-hibernate.module.name>
+        <javaModuleArgs/>
+
         <hazelcast.version>5.1.3</hazelcast.version>
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
@@ -66,7 +69,7 @@
 
         <junit.version>4.13.2</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>4.7.0</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <wiremock.version>2.27.2</wiremock.version>
 
@@ -237,6 +240,7 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <runOrder>failedfirst</runOrder>
                     <argLine>
+                        ${javaModuleArgs}
                         -Xms128m -Xmx1G
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
@@ -294,7 +298,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -385,6 +389,19 @@
     </dependencies>
     <profiles>
         <profile>
+            <id>jdk-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <!-- required only by Hibernate <5.3 -->
+                <javaModuleArgs>
+                    --add-opens java.base/java.lang=${hazelcast-hibernate.module.name}
+                    --illegal-access=deny
+                </javaModuleArgs>
+            </properties>
+        </profile>
+        <profile>
             <id>checkstyle</id>
             <build>
                 <plugins>
@@ -445,6 +462,7 @@
             <id>test-coverage</id>
             <properties>
                 <argLine>
+                    ${javaModuleArgs}
                     -Xms128m -Xmx1G
                     -Dhazelcast.version.check.enabled=false
                     -Dhazelcast.mancenter.enabled=false
@@ -591,7 +609,9 @@
                         <configuration combine.self="override">
                             <parallel>none</parallel>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                            <argLine>-Xms128m -Xmx1G
+                            <argLine>
+                                ${javaModuleArgs}
+                                -Xms128m -Xmx1G
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
 
-        <javaModuleArgs/>
-
         <hazelcast.version>5.1.3</hazelcast.version>
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
@@ -242,7 +240,6 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <runOrder>failedfirst</runOrder>
                     <argLine>
-                        ${javaModuleArgs}
                         -Xms128m -Xmx1G
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
@@ -391,19 +388,6 @@
     </dependencies>
     <profiles>
         <profile>
-            <id>jdk-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <!-- required only for tests with Hibernate <5.3 -->
-                <javaModuleArgs>
-                    --add-opens java.base/java.lang=ALL-UNNAMED
-                    --illegal-access=deny
-                </javaModuleArgs>
-            </properties>
-        </profile>
-        <profile>
             <id>checkstyle</id>
             <build>
                 <plugins>
@@ -464,7 +448,6 @@
             <id>test-coverage</id>
             <properties>
                 <argLine>
-                    ${javaModuleArgs}
                     -Xms128m -Xmx1G
                     -Dhazelcast.version.check.enabled=false
                     -Dhazelcast.mancenter.enabled=false
@@ -612,7 +595,6 @@
                             <parallel>none</parallel>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
-                                ${javaModuleArgs}
                                 -Xms128m -Xmx1G
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false


### PR DESCRIPTION
- Simplified workflows files using `cache` keyword in setup-java
- Switched CI workflow to use JDK17 for builds but also setup periodic snapshot builder to use JDK8 and JDK17
- Upgraded mockito to JDK17 compatible version
