### PR TITLE
Publish test results from fork-based PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,7 @@ jobs:
   build:
     needs: checkstyle
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        module: [ 'hazelcast-hibernate53' ]
-    name: Build ${{ matrix.module }}
+    name: Build
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK
@@ -42,13 +39,21 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -f ${{ matrix.module }}/pom.xml verify
+        run: mvn verify
 
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.0.0
-        if: ${{ !cancelled() }}
+      - name: Upload Test Results
+        if:  ${{ always() }}
+        uses: actions/upload-artifact@v3
         with:
-          check_name: Test results
-          files: '**/*-reports/TEST-*.xml'
+          name: Test Results
+          path: '**/*-reports/TEST-*.xml'
 
-
+  event_file:
+    name: Upload event file
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,37 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  publish-test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          junit_files: "artifacts/**/*.xml"


### PR DESCRIPTION
Fixed test publishing following the manual: https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches

Fixes
```
Request POST /repos/hazelcast/hazelcast-hibernate/check-runs failed with 403: Forbidden
Traceback (most recent call last):
  File "/action/publish_test_results.py", line 430, in <module>
    main(settings, gha)
  File "/action/publish_test_results.py", line 172, in main
    Publisher(settings, gh, gha).publish(stats, results.case_results, conclusion)
  File "/action/publish/publisher.py", line 152, in publish
    check_run, before_check_run = self.publish_check(stats, cases, conclusion)
  File "/action/publish/publisher.py", line [33](https://github.com/hazelcast/hazelcast-hibernate/actions/runs/3150388187/jobs/5123127717#step:6:34)1, in publish_check
    check_run = self._repo.create_check_run(name=self._settings.check_name,
  File "/usr/local/lib/python3.8/site-packages/github/Repository.py", line 3642, in create_check_run
    headers, data = self._requester.requestJsonAndCheck(
  File "/usr/local/lib/python3.8/site-packages/github/Requester.py", line [35](https://github.com/hazelcast/hazelcast-hibernate/actions/runs/3150388187/jobs/5123127717#step:6:36)4, in requestJsonAndCheck
    *self.requestJson(
  File "/usr/local/lib/python3.8/site-packages/github/Requester.py", line 454, in requestJson
    return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
  File "/usr/local/lib/python3.8/site-packages/github/Requester.py", line 528, in __requestEncode
    status, responseHeaders, output = self.__requestRaw(
  File "/action/publish_test_results.py", line 194, in throttled_gh_request_raw
    return gh_request_raw(cnx, verb, url, requestHeaders, input)
  File "/usr/local/lib/python3.8/site-packages/github/Requester.py", line 555, in __requestRaw
    response = cnx.getresponse()
  File "/usr/local/lib/python3.8/site-packages/github/Requester.py", line 127, in getresponse
    r = verb(
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 577, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/adapters.py", line 4[40](https://github.com/hazelcast/hazelcast-hibernate/actions/runs/3150388187/jobs/5123127717#step:6:41), in send
    resp = conn.urlopen(
  File "/usr/local/lib/python3.8/site-packages/urllib3/connectionpool.py", line 868, in urlopen
    retries = retries.increment(method, url, response=response, _pool=self)
  File "/action/publish/retry.py", line 101, in increment
    raise GithubException(response.status, content, response.headers)
github.GithubException.GithubException: 403 {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest/reference/checks#create-a-check-run"}
```