### PR TITLE
Trigger deploy-release from prepare-release by using deploy key

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,6 +14,8 @@ jobs:
           contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
       - name: Setup JDK
         uses: actions/setup-java@v3.6.0
         with:


### PR DESCRIPTION
Currently we use workflows for releasing:
- `prepare-release` prepares pom.xml and tag
- `deploy-release` actually perform the release whenever detects a new tag

It turned out that commits and tags created within a workflow don't trigger other workflows. In order to overcome this we need ot use a repository deploy key.

I've added a `COMMIT_KEY` deploy key (public key) and `COMMIT_KEY` repository secret (private key)