### PR TITLE
Support many addresses when setting up Hazelcast native client (#342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,15 +245,14 @@ Please see the <a href="http://docs.hazelcast.org/docs/latest/manual/html-single
 <property name="hibernate.cache.hazelcast.use_native_client">true</property>
 ```
 
-To set up Native Client, add the Hazelcast **group-name**, **group-password** and **cluster member address** (you can
+To set up Native Client, add the Hazelcast **cluster name** and **cluster member address** (you can
 also set multiple comma-separated addresses) properties. Native Client will connect to the defined member and will get
 the addresses of all members in the cluster. If the connected member dies or leaves the cluster, the client will
 automatically switch to another member in the cluster.
 
 ```xml  
 <property name="hibernate.cache.hazelcast.native_client_address">10.34.22.15, 10.34.22.16</property>
-<property name="hibernate.cache.hazelcast.native_client_group">dev</property>
-<property name="hibernate.cache.hazelcast.native_client_password">dev-pass</property>
+<property name="hibernate.cache.hazelcast.native_client_cluster_name">dev</property>
 ```
 
 You can use an existing client instead of creating a new one by adding the following property.

--- a/README.md
+++ b/README.md
@@ -245,10 +245,13 @@ Please see the <a href="http://docs.hazelcast.org/docs/latest/manual/html-single
 <property name="hibernate.cache.hazelcast.use_native_client">true</property>
 ```
 
-To set up Native Client, add the Hazelcast **group-name**, **group-password** and **cluster member address** properties. Native Client will connect to the defined member and will get the addresses of all members in the cluster. If the connected member dies or leaves the cluster, the client will automatically switch to another member in the cluster.
+To set up Native Client, add the Hazelcast **group-name**, **group-password** and **cluster member address** (you can
+also set multiple comma-separated addresses) properties. Native Client will connect to the defined member and will get
+the addresses of all members in the cluster. If the connected member dies or leaves the cluster, the client will
+automatically switch to another member in the cluster.
 
 ```xml  
-<property name="hibernate.cache.hazelcast.native_client_address">10.34.22.15</property>
+<property name="hibernate.cache.hazelcast.native_client_address">10.34.22.15, 10.34.22.16</property>
 <property name="hibernate.cache.hazelcast.native_client_group">dev</property>
 <property name="hibernate.cache.hazelcast.native_client_password">dev-pass</property>
 ```

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/CacheEnvironment.java
@@ -41,7 +41,7 @@ public final class CacheEnvironment {
     public static final String USE_NATIVE_CLIENT = "hibernate.cache.hazelcast.use_native_client";
 
     /**
-     * Property to configure the address for the Hazelcast client to connect to
+     * Property to configure the comma-seperated addresses for the Hazelcast client to connect to.
      */
     public static final String NATIVE_CLIENT_ADDRESS = "hibernate.cache.hazelcast.native_client_address";
 

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -74,7 +74,8 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
             clientConfig.setClusterName(clientClusterName);
         }
         if (address != null) {
-            clientConfig.getNetworkConfig().addAddress(address);
+            String[] addresses = address.trim().split("\\s*,\\s*");
+            clientConfig.getNetworkConfig().addAddress(addresses);
         }
 
         clientConfig.getNetworkConfig()
@@ -84,12 +85,19 @@ class HazelcastClientLoader implements IHazelcastInstanceLoader {
         // By default, try to connect a cluster with intervals starting with 2 sec and multiplied by 1.5
         // at each step with max backoff of 35 seconds
         clientConfig.getConnectionStrategyConfig()
-          .setReconnectMode(getFallback(toMap(props)) ? ASYNC : ON)
-          .getConnectionRetryConfig()
-          .setInitialBackoffMillis((int) getInitialBackoff(props).toMillis())
-          .setMaxBackoffMillis((int) getMaxBackoff(props).toMillis())
-          .setMultiplier(getBackoffMultiplier(props))
-          .setClusterConnectTimeoutMillis(getClusterTimeout(props).toMillis());
+                .setReconnectMode(getFallback(toMap(props)) ? ASYNC : ON)
+                .getConnectionRetryConfig()
+                .setInitialBackoffMillis((int) getInitialBackoff(props).toMillis())
+                .setMaxBackoffMillis((int) getMaxBackoff(props).toMillis())
+                .setMultiplier(getBackoffMultiplier(props))
+                .setClusterConnectTimeoutMillis(getClusterTimeout(props).toMillis());
+    }
+
+    /**
+     * Just for testing
+     */
+    ClientConfig getClientConfig() {
+        return clientConfig;
     }
 
     private Map<String, Object> toMap(Properties props) {

--- a/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/instance/HazelcastClientLoaderTest.java
+++ b/hazelcast-hibernate53/src/test/java/com/hazelcast/hibernate/instance/HazelcastClientLoaderTest.java
@@ -1,0 +1,33 @@
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.hibernate.HibernateTestSupport;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class HazelcastClientLoaderTest extends HibernateTestSupport {
+
+    @Test
+    public void configureMultipleAddresses() {
+        HazelcastClientLoader loader = new HazelcastClientLoader();
+        Properties props = new Properties();
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_ADDRESS, " localhost, 127.0.0.1 ");
+        loader.configure(props);
+        ClientConfig clientConfig = loader.getClientConfig();
+        Assertions.assertThat(clientConfig.getNetworkConfig().getAddresses()).containsExactly("localhost", "127.0.0.1");
+    }
+
+    @Test
+    public void configureSingleAddress() {
+        HazelcastClientLoader loader = new HazelcastClientLoader();
+        Properties props = new Properties();
+        props.setProperty(CacheEnvironment.NATIVE_CLIENT_ADDRESS, "localhost");
+        loader.configure(props);
+        ClientConfig clientConfig = loader.getClientConfig();
+        Assertions.assertThat(clientConfig.getNetworkConfig().getAddresses()).containsExactly("localhost");
+    }
+
+}


### PR DESCRIPTION
Users can setup multiple comma-separated addresses to connect to when using a native client

Fixes https://github.com/hazelcast/hazelcast-hibernate/issues/342
Fixes https://github.com/hazelcast/hazelcast-hibernate/issues/327