### PR TITLE
Prepare for next development iteration - 5.0.0-SNAPSHOT

### DIFF
--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-hibernate</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.3.1</version>
     </parent>
 
     <artifactId>hazelcast-hibernate53</artifactId>

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-hibernate</artifactId>
-        <version>2.3.1</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-hibernate53</artifactId>

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-hibernate</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-hibernate53</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>hazelcast-hibernate</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Hazelcast Platform Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>
@@ -80,7 +80,7 @@
         <connection>scm:git:git://github.com/hazelcast/hazelcast-hibernate.git</connection>
         <developerConnection>scm:git:git@github.com:hazelcast/hazelcast-hibernate.git</developerConnection>
         <url>https://github.com/hazelcast/hazelcast-hibernate/</url>
-        <tag>v2.3.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>hazelcast-hibernate</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.1</version>
     <packaging>pom</packaging>
     <description>Hazelcast Platform Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>
@@ -80,7 +80,7 @@
         <connection>scm:git:git://github.com/hazelcast/hazelcast-hibernate.git</connection>
         <developerConnection>scm:git:git@github.com:hazelcast/hazelcast-hibernate.git</developerConnection>
         <url>https://github.com/hazelcast/hazelcast-hibernate/</url>
-        <tag>HEAD</tag>
+        <tag>v2.3.1</tag>
     </scm>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>hazelcast-hibernate</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Hazelcast Platform Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>


### PR DESCRIPTION
We will jump to 5.0.0 the avoid conflicts with the old `hazelcast-hibernate` artefacts 