### PR TITLE
Change version of setup-java action to 'v3'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version:  17
           distribution: 'temurin'

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK 17
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'
@@ -54,7 +54,7 @@ jobs:
         run: ./mvnw compile
 
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           ref: "${{ env.TAG }}"
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version:  17
           distribution: 'temurin'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
       - name: Setup JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3
         with:
           java-version:  17
           distribution: 'temurin'


### PR DESCRIPTION
`setup-java@3.7.0` was deleted by the maintainers, see https://github.com/actions/setup-java/issues/422

We use basic functions of `setup-java` so we can use a major version only to avoid such problems and multiple dependabot PRs