### PR TITLE
Fix GitHub action build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hibernate Second Level Cache
 
-<a href="https://github.com/hazelcast/hazelcast-hibernate/actions?query=event%3Apush+branch%3Amaster"><img alt="GitHub Actions status" src="https://github.com/hazelcast/hazelcast-hibernate5/workflows/build/badge.svg"></a>
+<a href="https://github.com/hazelcast/hazelcast-hibernate/actions?query=event%3Apush+branch%3Amaster"><img alt="GitHub Actions status" src="[https://github.com/hazelcast/hazelcast-hibernate5/workflows/build/badge.svg](https://github.com/hazelcast/hazelcast-hibernate/actions/workflows/build.yml/badge.svg)"></a>
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/hazelcast-hibernate/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/hazelcast-hibernate53) 
 
 Hazelcast provides a distributed second-level cache for your Hibernate entities, collections, and queries.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hibernate Second Level Cache
 
-<a href="https://github.com/hazelcast/hazelcast-hibernate/actions?query=event%3Apush+branch%3Amaster"><img alt="GitHub Actions status" src="[https://github.com/hazelcast/hazelcast-hibernate5/workflows/build/badge.svg](https://github.com/hazelcast/hazelcast-hibernate/actions/workflows/build.yml/badge.svg)"></a>
+<a href="https://github.com/hazelcast/hazelcast-hibernate/actions?query=event%3Apush+branch%3Amaster"><img alt="GitHub Actions status" src="https://github.com/hazelcast/hazelcast-hibernate/actions/workflows/build.yml/badge.svg"></a>
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/hazelcast-hibernate/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/hazelcast-hibernate53) 
 
 Hazelcast provides a distributed second-level cache for your Hibernate entities, collections, and queries.


### PR DESCRIPTION
The build status badge does not load as the URL is incorrect, resolved by getting the latest badge URL from the [build job](https://github.com/hazelcast/hazelcast-hibernate/actions/workflows/build.yml).

![Screenshot 2023-11-15 at 20 48 57](https://github.com/hazelcast/hazelcast-hibernate/assets/8626721/642e4ee0-f05f-44f8-b886-6bd034f6f132)
