### PR TITLE
Upgrade hibernate to 6.4.2.Final

### DIFF
--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-hibernate</artifactId>
-        <version>5.4.0-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-hibernate53</artifactId>

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-hibernate</artifactId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hazelcast-hibernate53</artifactId>

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -155,7 +155,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     }
 
     @Override
-    protected void prepareForUse(final SessionFactoryOptions settings, Map<String,Object> configValues) {
+    protected void prepareForUse(final SessionFactoryOptions settings, Map<String, Object> configValues) {
         log.info("Starting up " + getClass().getSimpleName());
         if (instance == null || !instance.getLifecycleService().isRunning()) {
             instanceLoader = resolveInstanceLoader(toProperties(configValues));
@@ -193,7 +193,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         }
     }
 
-    private Properties toProperties(Map<String,Object> configValues) {
+    private Properties toProperties(Map<String, Object> configValues) {
         final Properties properties = new Properties();
         properties.putAll(configValues);
         return properties;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -59,18 +59,24 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     private IHazelcastInstanceLoader instanceLoader;
 
     @SuppressWarnings("unused")
-    public AbstractHazelcastCacheRegionFactory() {
+    protected AbstractHazelcastCacheRegionFactory() {
         this(DefaultCacheKeysFactory.INSTANCE);
     }
 
-    public AbstractHazelcastCacheRegionFactory(CacheKeysFactory cacheKeysFactory) {
+    protected AbstractHazelcastCacheRegionFactory(CacheKeysFactory cacheKeysFactory) {
         this.cacheKeysFactory = cacheKeysFactory;
         this.phoneHomeService = new PhoneHomeService(phoneHomeInfo());
     }
 
-    public AbstractHazelcastCacheRegionFactory(PhoneHomeService phoneHomeService) {
+    protected AbstractHazelcastCacheRegionFactory(PhoneHomeService phoneHomeService) {
         this.phoneHomeService = phoneHomeService;
         cacheKeysFactory = DefaultCacheKeysFactory.INSTANCE;
+    }
+
+    protected AbstractHazelcastCacheRegionFactory(HazelcastInstance instance) {
+        this.instance = instance;
+        this.cacheKeysFactory = DefaultCacheKeysFactory.INSTANCE;
+        this.phoneHomeService = new PhoneHomeService(phoneHomeInfo());
     }
 
     @Override
@@ -149,7 +155,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     }
 
     @Override
-    protected void prepareForUse(final SessionFactoryOptions settings, final Map configValues) {
+    protected void prepareForUse(final SessionFactoryOptions settings, Map<String,Object> configValues) {
         log.info("Starting up " + getClass().getSimpleName());
         if (instance == null || !instance.getLifecycleService().isRunning()) {
             instanceLoader = resolveInstanceLoader(toProperties(configValues));
@@ -187,7 +193,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         }
     }
 
-    private Properties toProperties(final Map configValues) {
+    private Properties toProperties(Map<String,Object> configValues) {
         final Properties properties = new Properties();
         properties.putAll(configValues);
         return properties;

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastCacheRegionFactory.java
@@ -15,6 +15,7 @@
 
 package com.hazelcast.hibernate;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.distributed.IMapRegionCache;
 import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
 import org.hibernate.cache.spi.CacheKeysFactory;
@@ -37,6 +38,10 @@ public class HazelcastCacheRegionFactory extends AbstractHazelcastCacheRegionFac
 
     public HazelcastCacheRegionFactory(PhoneHomeService phoneHomeService) {
         super(phoneHomeService);
+    }
+
+    public HazelcastCacheRegionFactory(HazelcastInstance instance) {
+        super(instance);
     }
 
     @Override

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/HazelcastLocalCacheRegionFactory.java
@@ -15,6 +15,7 @@
 
 package com.hazelcast.hibernate;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.hibernate.local.TimestampsRegionCache;
 import com.hazelcast.internal.util.Clock;
@@ -39,6 +40,10 @@ public class HazelcastLocalCacheRegionFactory extends AbstractHazelcastCacheRegi
 
     public HazelcastLocalCacheRegionFactory(PhoneHomeService phoneHomeService) {
         super(phoneHomeService);
+    }
+
+    public HazelcastLocalCacheRegionFactory(HazelcastInstance instance) {
+        super(instance);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>hazelcast-hibernate</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate</artifactId>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Hazelcast Platform Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <name>hazelcast-hibernate</name>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-hibernate</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Hazelcast Platform Hibernate Plugin</description>
     <url>http://www.hazelcast.com/</url>
@@ -56,7 +56,7 @@
         <sonar.verbose>true</sonar.verbose>
 
         <hsqldb.version>2.7.1</hsqldb.version>
-        <hibernate.core.version>6.1.3.Final</hibernate.core.version>
+        <hibernate.core.version>6.4.2.Final</hibernate.core.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
         <jaxb-core.version>4.0.4</jaxb-core.version>
 
@@ -312,7 +312,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.core.version}</version>
             <scope>provided</scope>


### PR DESCRIPTION
Content of the PR : 

- The coordinates of hibernate has changed on maven. Use new coordinates
- Upgrade version of projects to 5.4.0-SNAPHOT
-  AbstractHazelcastCacheRegionFactory needs a new constructor that is : AbstractHazelcastCacheRegionFactory(HazelcastInstance instance)

The reason is Hazelcast spring code is injecting HazelcastInstance with constructor. The current tests are using hazelcast-hibernate5 dependency which had this constructor. But currently the hazelcast-hibernate5 has been deleted, and it is now hazelcast-hibernate53. But hazelcast-hibernate53 did not bring in the required constructor.

So after this PR is merged, in a new PR for HZ spring tests is required. It will upgrade to use hazelcast-hibernate53