### PR TITLE
Update supported Hazelcast and Hibernate versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw -B install -DskipTests -Pcheckstyle,findbugs
+        run: ./mvnw --batch-mode install -DskipTests -Pcheckstyle,findbugs
 
   build:
     needs: checkstyle
@@ -35,7 +35,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw verify
+        run: ./mvnw --batch-mode verify
 
       - name: Upload Test Results
         if:  ${{ always() }}

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -47,7 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '21' ]
+        hazelcast: [ '5.4.0' ]
+        java: [ '17', '21' ]
+        include:
+          - hazelcast: '5.3.7'
+            java: '11'
     name: Test against JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4
@@ -69,5 +73,5 @@ jobs:
           cache: 'maven'
 
       - name: Run tests against JDK ${{ matrix.java }}
-        run: JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw verify -Dmaven.main.skip=true
+        run: JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }}
 

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -37,10 +37,10 @@ jobs:
           cache: 'maven'
 
       - name: Compile with default Hazelcast and Hibernate
-        run: ./mvnw compile
+        run: ./mvnw --batch-mode compile
 
       - name: Run tests against HZ ${{ matrix.hazelcast }} and HN ${{ matrix.hibernate }}
-        run: ./mvnw verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }} -Dhibernate.core.version=${{ matrix.hibernate }}
+        run: ./mvnw --batch-mode verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }} -Dhibernate.core.version=${{ matrix.hibernate }}
 
   test-jdks:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compatibility-sensitive')
@@ -63,7 +63,7 @@ jobs:
           cache: 'maven'
 
       - name: Compile with JDK 17
-        run: ./mvnw compile
+        run: ./mvnw --batch-mode compile
 
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -73,5 +73,5 @@ jobs:
           cache: 'maven'
 
       - name: Run tests against JDK ${{ matrix.java }}
-        run: JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }}
+        run: JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw --batch-mode verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }}
 

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hazelcast: [ '${{env.LATEST_HZ_RELEASE}}' ]
+        hazelcast: [ '$LATEST_HZ_RELEASE' ]
         java: [ '17', '21' ]
         include:
           - hazelcast: '5.3.7'

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -50,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hazelcast: [ '$LATEST_HZ_RELEASE' ]
+        hazelcast: [ $LATEST_HZ_RELEASE ]
         java: [ '17', '21' ]
         include:
           - hazelcast: '5.3.7'
             java: '11'
-    name: Test against JDK ${{ matrix.java }}
+    name: Test against JDK ${{ matrix.java }} and HZ ${{ matrix.hazelcast }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK 17
@@ -75,6 +75,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Run tests against JDK ${{ matrix.java }}
+      - name: Run tests against JDK ${{ matrix.java }} and HZ ${{ matrix.hazelcast }}
         run: JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw --batch-mode verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }}
 

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch:
   workflow_call:
 
-env:
-  LATEST_HZ_RELEASE: '5.4.0'
-
 jobs:
   build:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compatibility-sensitive')
@@ -50,9 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hazelcast: [ $LATEST_HZ_RELEASE ]
+        # Run with latest Hazelcast release
+        hazelcast: [ '5.4.0' ]
         java: [ '17', '21' ]
         include:
+          # And the 5.3.z release still supports Java 11
           - hazelcast: '5.3.7'
             java: '11'
     name: Test against JDK ${{ matrix.java }} and HZ ${{ matrix.hazelcast }}

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hazelcast: [ ${{ env.LATEST_HZ_RELEASE }} ]
+        hazelcast: [ '${{env.LATEST_HZ_RELEASE}}' ]
         java: [ '17', '21' ]
         include:
           - hazelcast: '5.3.7'

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  LATEST_HZ_RELEASE: '5.4.0'
+
 jobs:
   build:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compatibility-sensitive')
@@ -47,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hazelcast: [ '5.4.0' ]
+        hazelcast: [ '${{ env.LATEST_HZ_RELEASE }}' ]
         java: [ '17', '21' ]
         include:
           - hazelcast: '5.3.7'

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hazelcast: [ '${{ env.LATEST_HZ_RELEASE }}' ]
+        hazelcast: [ ${{ env.LATEST_HZ_RELEASE }} ]
         java: [ '17', '21' ]
         include:
           - hazelcast: '5.3.7'

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -17,8 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hazelcast: [ '4.2.8', '5.0.4', '5.1.6', '5.2.3', '5.3.0', '5.4.0-SNAPSHOT' ]
-        hibernate: [ '5.3.30.Final', '5.4.33.Final', '5.5.9.Final', '5.6.15.Final', '6.0.2.Final', '6.1.7.Final', '6.2.4.Final' ]
+        hazelcast: [ '5.3.7', '5.4.0', '5.5.0-SNAPSHOT' ]
+        # Versions marked latest stable and limited-support from https://hibernate.org/orm/releases/
+        hibernate: [
+          '5.3.36.Final',
+          '5.6.15.Final',
+          '6.2.25.Final',
+          '6.4.8.Final',
+          '6.5.2.Final'
+        ]
     name: Test against HZ ${{ matrix.hazelcast }} and HN ${{ matrix.hibernate }}
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '21' ]
+        java: [ '11', '17', '21' ]
     name: Test against JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4

--- a/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate53/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -155,7 +155,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
     }
 
     @Override
-    protected void prepareForUse(final SessionFactoryOptions settings, Map<String, Object> configValues) {
+    protected void prepareForUse(SessionFactoryOptions settings, Map configValues) {
         log.info("Starting up " + getClass().getSimpleName());
         if (instance == null || !instance.getLifecycleService().isRunning()) {
             instanceLoader = resolveInstanceLoader(toProperties(configValues));
@@ -193,7 +193,7 @@ public abstract class AbstractHazelcastCacheRegionFactory extends RegionFactoryT
         }
     }
 
-    private Properties toProperties(Map<String, Object> configValues) {
+    private Properties toProperties(Map<?, ?> configValues) {
         final Properties properties = new Properties();
         properties.putAll(configValues);
         return properties;

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <hazelcast.version>5.3.0</hazelcast.version>
+        <hazelcast.version>5.4.0</hazelcast.version>
 
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.4.1</maven.jar.plugin.version>
@@ -56,7 +56,7 @@
         <sonar.verbose>true</sonar.verbose>
 
         <hsqldb.version>2.7.1</hsqldb.version>
-        <hibernate.core.version>6.4.2.Final</hibernate.core.version>
+        <hibernate.core.version>6.5.2.Final</hibernate.core.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
         <jaxb-core.version>4.0.4</jaxb-core.version>
 
@@ -88,6 +88,12 @@
             <organization>Hazelcast</organization>
             <organizationUrl>https://hazelcast.com</organizationUrl>
         </developer>
+        <developer>
+            <id>frant-hartm</id>
+            <name>František Hartman</name>
+            <organization>Hazelcast</organization>
+            <organizationUrl>https://hazelcast.com</organizationUrl>
+        </developer>
     </developers>
     <build>
         <plugins>
@@ -97,7 +103,7 @@
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <release>17</release>
+                    <release>11</release>
                 </configuration>
             </plugin>
 
@@ -312,7 +318,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${hibernate.core.version}</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>1.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.2.0</version>


### PR DESCRIPTION
- Hazelcast 5.3.7, 5.4.0 and 5.5.0-SNAPSHOT
- Add missing test dependency to run tests with Hazelcast 5.5.0-SNAPSHOT
- Hibernate 5.3.36.Final, 5.6.15.Final, 6.2.25.Final, 6.4.8.Final, 6.5.2.Final
- JDK 11 (this was previsously removed, but we need it because Hazelcast 5.3.z supports JDK 11)