### PR TITLE
Increase Renovate concurrent PR limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "schedule": [
     "after 2am on Thursday"
   ],
+  "prConcurrentLimit": 100,
   "packageRules": [
     {
       "managers": ["maven"],


### PR DESCRIPTION
By default, [Renovate is limited to 10 concurrent PRs](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit).

Updated configuration to match the limit for Dependabot.