### PR TITLE
Use commit hash (not tag) for `EnricoMi/publish-unit-test-result-action` version specification

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -29,7 +29,7 @@ jobs:
            done
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@567cc7f8dcea3eba5da355f6ebc95663310d8a07
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json


### PR DESCRIPTION
Currently we are referencing a tag when specifying the version of the `EnricoMi/publish-unit-test-result-action`, which is potentially mutable.

[It was requested](https://github.com/hazelcast/hazelcast-mono/pull/2422/files/e0b1647cd0e713602c2fe215bf253510637d8037#r1727207988) that the commit SHA be used instead, as per the [GitHub actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Updated the version specification to the commit hash of the [currently used version](https://github.com/EnricoMi/publish-unit-test-result-action/releases/tag/v2.17.0) - i.e. no changes to the actual version of the action being used.