### PR TITLE
Migrate hazelcast-hibernate to new portal [DI-626]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,32 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     name: Checkstyle
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw --batch-mode install -DskipTests -Pcheckstyle,findbugs
+        run: ./mvnw --batch-mode --no-transfer-progress install -DskipTests -Pcheckstyle,findbugs
 
   build:
     needs: checkstyle
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version:  17
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Build with Maven
-        run: ./mvnw --batch-mode verify
+        run: ./mvnw --batch-mode --no-transfer-progress verify
 
       - name: Upload Test Results
         if:  ${{ always() }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -32,7 +32,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: deploy-repository
+          server-id: release-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -32,7 +32,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: release-repository
+          server-id: deploy-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -23,11 +23,11 @@ jobs:
           fi
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "VERSION=${TAG:1}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: "${{ env.TAG }}"
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -39,7 +39,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Deploy release
-        run: ./mvnw deploy -Prelease --batch-mode -DskipTests -DretryFailedDeploymentCount=3
+        run: ./mvnw deploy -Prelease --batch-mode --no-transfer-progress -DskipTests -DretryFailedDeploymentCount=3
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -13,19 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy snapshot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version:  17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: snapshot-repository
+          server-id: deploy-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
       - name: Deploy snapshot
-        run: ./mvnw deploy -Prelease-snapshot --batch-mode --update-snapshots -DskipTests -DretryFailedDeploymentCount=3
+        run: ./mvnw deploy -Prelease-snapshot --batch-mode --no-transfer-progress --update-snapshots -DskipTests -DretryFailedDeploymentCount=3
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
           java-version:  17
           distribution: 'temurin'
           cache: 'maven'
-          server-id: deploy-repository
+          server-id: snapshot-repository
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 

--- a/hazelcast-hibernate53/pom.xml
+++ b/hazelcast-hibernate53/pom.xml
@@ -20,6 +20,7 @@
         <version>5.3.0-SNAPSHOT</version>
     </parent>
 
+    <name>hazelcast-hibernate53</name>
     <artifactId>hazelcast-hibernate53</artifactId>
     <packaging>jar</packaging>
     <description>Hazelcast Platform Hibernate Plugin</description>

--- a/pom.xml
+++ b/pom.xml
@@ -230,9 +230,9 @@
 
     <repositories>
         <repository>
-            <id>snapshot-repository</id>
+            <id>deploy-repository</id>
             <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -252,19 +252,6 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>release-repository</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>snapshot-repository</id>
-            <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <uniqueVersion>false</uniqueVersion>
-        </snapshotRepository>
-    </distributionManagement>
 
     <dependencies>
         <dependency>
@@ -534,14 +521,21 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>release-repository</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <!-- server id comes from settings.xml -->
+                            <publishingServerId>deploy-repository</publishingServerId>
+                            <!--
+                            wait until the artifacts are actually published automatically using 'autoPublish'.
+                            the default is `validated` which would then require manual publishing
+                            -->
+                            <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
+                            <checksums>required</checksums>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>
                     </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
 
     <repositories>
         <repository>
-            <id>deploy-repository</id>
+            <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <releases>
@@ -255,7 +255,7 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>deploy-repository</id>
+            <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <uniqueVersion>false</uniqueVersion>
@@ -536,12 +536,13 @@
                         <extensions>true</extensions>
                         <configuration>
                             <!-- server id comes from settings.xml -->
-                            <publishingServerId>deploy-repository</publishingServerId>
+                            <publishingServerId>release-repository</publishingServerId>
                             <!--
                             wait until the artifacts are actually published automatically using 'autoPublish'.
                             the default is `validated` which would then require manual publishing
                             -->
-                            <autoPublish>false</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
                             <checksums>required</checksums>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -532,8 +532,7 @@
                             wait until the artifacts are actually published automatically using 'autoPublish'.
                             the default is `validated` which would then require manual publishing
                             -->
-                            <waitUntil>published</waitUntil>
-                            <autoPublish>true</autoPublish>
+                            <autoPublish>false</autoPublish>
                             <checksums>required</checksums>
                             <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,15 @@
         </repository>
     </repositories>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>deploy-repository</id>
+            <name>Maven2 Snapshot Repository</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
+            <uniqueVersion>false</uniqueVersion>
+        </snapshotRepository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
@@ -534,7 +543,6 @@
                             -->
                             <autoPublish>false</autoPublish>
                             <checksums>required</checksums>
-                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>
                     </plugin>
 


### PR DESCRIPTION
### Changes
1. only OSS project
2. ported changes from [hazelcast-jdbc#502](https://github.com/hazelcast/hazelcast-jdbc/pull/502)
3. `snapshot` deployment is not handled by the new plugin as [deploy-release.yml](https://github.com/hazelcast/hazelcast-hibernate/blob/migrate-maven-to-new-portal/.github/workflows/deploy-release.yml#L42) and [deploy-snapshot.yml](https://github.com/hazelcast/hazelcast-hibernate/blob/migrate-maven-to-new-portal/.github/workflows/deploy-snapshot.yml#L28) use different Maven profiles
4. added missing project `<name>` for `hazelcast-hibernate53`
5. added Maven option `--no-transfer-progress`
6. updated `action` versions

### Testing:
#### Snapshot
Version: 5.3.0-SNAPSHOT
1. Build deployed [successfully](https://github.com/hazelcast/hazelcast-hibernate/actions/runs/18042940741)
2. Checked Central - [hazelcast-hibernate/maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/hazelcast-hibernate/5.3.0-SNAPSHOT/maven-metadata.xml) and [hazelcast-hibernate53/maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/hazelcast-hibernate53/5.3.0-SNAPSHOT/maven-metadata.xml)

#### Release
Version: `0.1.1` (`1.1.1` already exists)

1. made temp changes on a separate branch ([diff](https://github.com/hazelcast/hazelcast-hibernate/compare/migrate-maven-to-new-portal...TEST-migrate-maven-to-new-portal))
2. Release build validated [successfully](https://github.com/hazelcast/hazelcast-hibernate/actions/runs/18043047370/job/51346870864)
3. <img width="794" height="324" alt="image" src="https://github.com/user-attachments/assets/d1d03b54-4f36-420a-8b13-07a91d1cbd84" />

Post tasks
- [x] cleanup staged deployments
- [x] delete temp branch

Fixes: [DI-626](https://hazelcast.atlassian.net/browse/DI-626)

[DI-626]: https://hazelcast.atlassian.net/browse/DI-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ