### PR TITLE
Replace GitHub pat with `github.token` + `permissions`

### DIFF
--- a/.github/workflows/drafter.yml
+++ b/.github/workflows/drafter.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: release-drafter/release-drafter@v6.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,8 +19,6 @@ jobs:
     needs: compatibility-tests
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: "${{ secrets.GH_PAT }}"
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Download and Extract Artifacts
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
            mkdir -p artifacts && cd artifacts
 


### PR DESCRIPTION
We should not require the use of a (long-living) PAT, instead the implicit `github.token` along with the requisite `permissions` should be sufficient.

Unfortunately, as this is in a release-centric action I am unable to test this change without doing a release.