### PR TITLE
Replace `SNAPSHOT_INTERNAL` secrets with tokenless-OIDC authentication [DI-706]

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compatibility-sensitive')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -36,11 +38,24 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - uses: hazelcast/docker-actions/setup-maven-snapshot-internal@master
+        with:
+          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+
       - name: Compile with default Hazelcast and Hibernate
-        run: ./mvnw --batch-mode compile
+        run: |
+          ./mvnw \
+            compile \
+            --batch-mode 
 
       - name: Run tests against HZ ${{ matrix.hazelcast }} and HN ${{ matrix.hibernate }}
-        run: ./mvnw --settings settings.xml --batch-mode verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }} -Dhibernate.core.version=${{ matrix.hibernate }} -Dhz.snapshot.internal.username=${{ secrets.HZ_SNAPSHOT_INTERNAL_USERNAME }} -Dhz.snapshot.internal.password=${{ secrets.HZ_SNAPSHOT_INTERNAL_PASSWORD }}
+        run: |
+          ./mvnw \
+            verify \
+            --batch-mode \
+            -Dhazelcast.version=${{ matrix.hazelcast }} \
+            -Dhibernate.core.version=${{ matrix.hibernate }} \
+            -Dmaven.main.skip=true
 
   test-jdks:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compatibility-sensitive')
@@ -68,7 +83,10 @@ jobs:
           cache: 'maven'
 
       - name: Compile with JDK 17
-        run: ./mvnw --batch-mode compile
+        run: |
+          ./mvnw \
+            compile \
+            --batch-mode 
 
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -78,5 +96,10 @@ jobs:
           cache: 'maven'
 
       - name: Run tests against JDK ${{ matrix.java }} and HZ ${{ matrix.hazelcast }}
-        run: JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw --batch-mode verify -Dmaven.main.skip=true -Dhazelcast.version=${{ matrix.hazelcast }} -Djakarta.version=${{ matrix.jakarta }}
-
+        run: |
+          JAVA_HOME=${JAVA_HOME_${{ matrix.java }}_x64} ./mvnw \
+            verify
+            --batch-mode \
+            -Dhazelcast.version=${{ matrix.hazelcast }} \
+            -Djakarta.version=${{ matrix.jakarta }} \
+            -Dmaven.main.skip=true

--- a/settings.xml
+++ b/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-    <servers>
-        <server>
-            <id>snapshot-internal</id>
-            <username>${hz.snapshot.internal.username}</username>
-            <password>${hz.snapshot.internal.password}</password>
-        </server>
-    </servers>
-</settings>


### PR DESCRIPTION
See 
- https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws
- [ADR](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/6645022721/ADR-00089-+Type+2+-Migrate+GitHub+Actions+to+use+tokenless+OIDC+authentication)
- [reference `hazelcast-docker` implementation](https://github.com/hazelcast/hazelcast-docker/pull/1197)

To improve readability, also formatted `mvn` commands to be split over multiple lines, with alphabetically-ordered arguments.

[Example execution](https://github.com/hazelcast/hazelcast-hibernate/actions/runs/23793272730) - fails, but for unrelated reasons - you can see it's not an authentication issue at least.

Fixes: [DI-706](https://hazelcast.atlassian.net/browse/DI-706)

[DI-706]: https://hazelcast.atlassian.net/browse/DI-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ