### PR TITLE
Fix broken Maven central badge in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hibernate Second Level Cache
 
 <a href="https://github.com/hazelcast/hazelcast-hibernate/actions?query=event%3Apush+branch%3Amaster"><img alt="GitHub Actions status" src="https://github.com/hazelcast/hazelcast-hibernate/actions/workflows/build.yml/badge.svg"></a>
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/hazelcast-hibernate/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/hazelcast-hibernate53) 
+[![Maven Central](https://maven-badges.sml.io/maven-central/com.hazelcast/hazelcast-hibernate/badge.svg)](https://maven-badges.sml.io/maven-central/com.hazelcast/hazelcast-hibernate53) 
 
 Hazelcast provides a distributed second-level cache for your Hibernate entities, collections, and queries.
 


### PR DESCRIPTION
The Maven central badge in `README` does not load; the [URL to the badge has changed](https://github.com/softwaremill/maven-badges#a-new-dns-address).

As such, updated.