### PR TITLE
Rescope AWS ARN from `secret` to `var`

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: hazelcast/docker-actions/setup-maven-snapshot-internal@master
         with:
-          aws-role-to-assume: ${{ secrets.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
 
       - name: Compile with default Hazelcast and Hibernate
         run: |


### PR DESCRIPTION
The name of the role isn't a `secret`, so storing at such means it's masked logs etc which makes debugging difficult. More specifically, authentication is handled via [OIDC](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws), on it's own the role does nothing.

Instead, it should be rescoped as a `var`.